### PR TITLE
Add Compose theme files and example activity

### DIFF
--- a/android/app/src/main/java/com/example/fortune/MainActivity.kt
+++ b/android/app/src/main/java/com/example/fortune/MainActivity.kt
@@ -1,0 +1,33 @@
+package com.example.fortune
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.fortune.ui.theme.FortuneTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            FortuneTheme {
+                Greeting()
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting() {
+    Text(text = "Hello Fortune")
+}
+
+@Preview
+@Composable
+fun GreetingPreview() {
+    FortuneTheme {
+        Greeting()
+    }
+}

--- a/android/app/src/main/java/com/example/fortune/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/example/fortune/ui/theme/Color.kt
@@ -1,0 +1,13 @@
+package com.example.fortune.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val md_theme_light_primary = Color(0xFF4B0082)
+val md_theme_light_secondary = Color(0xFFFFD700)
+val md_theme_light_background = Color(0xFFE6E6FA)
+val md_theme_light_surface = Color(0xFFFFFFFF)
+
+val md_theme_dark_primary = Color(0xFF9E7BFF)
+val md_theme_dark_secondary = Color(0xFFFFE066)
+val md_theme_dark_background = Color(0xFF1C1C1E)
+val md_theme_dark_surface = Color(0xFF2C2C2E)

--- a/android/app/src/main/java/com/example/fortune/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/example/fortune/ui/theme/Theme.kt
@@ -1,0 +1,32 @@
+package com.example.fortune.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val LightColors = lightColorScheme(
+    primary = md_theme_light_primary,
+    secondary = md_theme_light_secondary,
+    background = md_theme_light_background,
+    surface = md_theme_light_surface
+)
+
+private val DarkColors = darkColorScheme(
+    primary = md_theme_dark_primary,
+    secondary = md_theme_dark_secondary,
+    background = md_theme_dark_background,
+    surface = md_theme_dark_surface
+)
+
+@Composable
+fun FortuneTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+    val colors = if (darkTheme) DarkColors else LightColors
+
+    MaterialTheme(
+        colorScheme = colors,
+        typography = AppTypography,
+        content = content
+    )
+}

--- a/android/app/src/main/java/com/example/fortune/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/example/fortune/ui/theme/Type.kt
@@ -1,0 +1,25 @@
+package com.example.fortune.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val AppTypography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 36.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Light,
+        fontSize = 12.sp
+    )
+)


### PR DESCRIPTION
## Summary
- add Jetpack Compose theme definitions with light and dark colors
- define app typography
- create `FortuneTheme` for applying colors/typography
- add example `MainActivity` using the theme

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb760a2c832f8c2c91221fad9d95