### PR TITLE
Add TODO for Jetpack Compose integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## TODO
+
+This repository currently focuses on a Next.js implementation. A request was
+made to integrate Jetpack Navigation Compose for an Android version, but no
+Android module exists yet. If Android support is added in the future, set up
+Navigation Compose with a `Screen` sealed class (`Home`, `Tarot`, `Saju`,
+`More`) and a `NavHost` inside `MainActivity.kt` using
+`rememberNavController()`.


### PR DESCRIPTION
## Summary
- update README with a TODO explaining that there's no Android module yet

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb7dcc9c832fb72886c0ca50f9b2