### PR TITLE
Add Hilt module for MBTI repository

### DIFF
--- a/android/di/RepositoryModule.kt
+++ b/android/di/RepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.example.di
+
+import com.example.repository.MbtiRepository
+import com.example.repository.MbtiRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindMbtiRepository(
+        impl: MbtiRepositoryImpl
+    ): MbtiRepository
+}

--- a/android/repository/MbtiRepository.kt
+++ b/android/repository/MbtiRepository.kt
@@ -1,0 +1,5 @@
+package com.example.repository
+
+interface MbtiRepository {
+    fun getMbtiType(): String
+}

--- a/android/repository/MbtiRepositoryImpl.kt
+++ b/android/repository/MbtiRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.example.repository
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MbtiRepositoryImpl @Inject constructor() : MbtiRepository {
+    override fun getMbtiType(): String {
+        // Placeholder implementation
+        return "ISTJ"
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an example Android structure
- add `MbtiRepository` interface with a placeholder implementation
- create `RepositoryModule` with `@Binds` and `@Singleton` to bind the repository

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853eba881b4832fa874a6e6a2c485d0