### PR TITLE
Add Physiognomy API service and repo

### DIFF
--- a/android/src/main/java/com/example/physiognomy/data/PhysiognomyRepository.kt
+++ b/android/src/main/java/com/example/physiognomy/data/PhysiognomyRepository.kt
@@ -1,0 +1,30 @@
+package com.example.physiognomy.data
+
+import android.content.Context
+import android.net.Uri
+import com.example.physiognomy.data.remote.PhysiognomyApiService
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+
+/**
+ * Repository that uploads an image for physiognomy analysis using [PhysiognomyApiService].
+ */
+class PhysiognomyRepository(
+    private val context: Context,
+    private val api: PhysiognomyApiService
+) {
+
+    /**
+     * Converts the given [Uri] to [MultipartBody.Part] and sends it to the API.
+     */
+    suspend fun analyzeSelectedImage(imageUri: Uri) = api.analyzeFace(toMultipart(imageUri))
+
+    private fun toMultipart(uri: Uri): MultipartBody.Part {
+        val stream = context.contentResolver.openInputStream(uri)
+            ?: throw IllegalArgumentException("Unable to open URI: $uri")
+        val bytes = stream.readBytes()
+        val requestBody = RequestBody.create("image/*".toMediaTypeOrNull(), bytes)
+        return MultipartBody.Part.createFormData("file", "image.jpg", requestBody)
+    }
+}

--- a/android/src/main/java/com/example/physiognomy/data/remote/PhysiognomyApiService.kt
+++ b/android/src/main/java/com/example/physiognomy/data/remote/PhysiognomyApiService.kt
@@ -1,0 +1,22 @@
+package com.example.physiognomy.data.remote
+
+import okhttp3.MultipartBody
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+/**
+ * Retrofit interface for physiognomy analysis.
+ */
+interface PhysiognomyApiService {
+    /**
+     * Uploads an image to the `analyze` endpoint for face analysis.
+     */
+    @Multipart
+    @POST("analyze")
+    suspend fun analyzeFace(
+        @Part image: MultipartBody.Part
+    ): Response<ResponseBody>
+}


### PR DESCRIPTION
## Summary
- add Retrofit service interface for physiognomy API
- add repository helper to upload an image Uri via the API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853ebd9d56c832f8721a537a1d072f2