### PR TITLE
Implement MainScreen Compose layout

### DIFF
--- a/android/src/main/java/com/example/fortune/MainScreen.kt
+++ b/android/src/main/java/com/example/fortune/MainScreen.kt
@@ -1,0 +1,28 @@
+package com.example.fortune
+
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun MainScreen(navController: NavHostController = rememberNavController()) {
+    Scaffold(
+        bottomBar = { BottomNavigationBar(navController) }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = "home",
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            // TODO: Define your composable destinations here
+            composable("home") {
+                // HomeScreen()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Android Compose `MainScreen.kt` with Scaffold and NavHost

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'react' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb909ccc832f9cdc7e5dbb952864