### PR TITLE
Add DreamSearchViewModel with flow-based search

### DIFF
--- a/android/src/main/java/com/example/dream/DreamModels.kt
+++ b/android/src/main/java/com/example/dream/DreamModels.kt
@@ -1,0 +1,12 @@
+package com.example.dream
+
+import kotlinx.coroutines.flow.Flow
+
+data class DreamResult(
+    val id: String,
+    val description: String
+)
+
+interface DreamRepository {
+    fun search(query: String): Flow<List<DreamResult>>
+}

--- a/android/src/main/java/com/example/dream/DreamSearchViewModel.kt
+++ b/android/src/main/java/com/example/dream/DreamSearchViewModel.kt
@@ -1,0 +1,37 @@
+package com.example.dream
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DreamSearchViewModel @Inject constructor(
+    private val dreamRepository: DreamRepository
+) : ViewModel() {
+
+    val searchText = MutableStateFlow("")
+
+    private val _searchResults = MutableStateFlow<List<DreamResult>>(emptyList())
+    val searchResults: StateFlow<List<DreamResult>> = _searchResults.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            snapshotFlow { searchText.value }
+                .debounce(500)
+                .distinctUntilChanged()
+                .flatMapLatest { query ->
+                    if (query.isBlank()) {
+                        flowOf(emptyList())
+                    } else {
+                        dreamRepository.search(query)
+                    }
+                }
+                .collect { results ->
+                    _searchResults.value = results
+                }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DreamResult` data class and `DreamRepository` interface
- add `DreamSearchViewModel` that uses Hilt injection and debounce search logic

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6853ebc55284832f802d9f50627c8f8f