### PR TITLE
Enhance Genkit input validation

### DIFF
--- a/src/ai/flows/generate-fortune-insights.ts
+++ b/src/ai/flows/generate-fortune-insights.ts
@@ -12,11 +12,36 @@
 import {ai} from '@/ai/genkit';
 import {z} from 'genkit';
 
+const MBTI_TYPES = [
+  'INTJ',
+  'INTP',
+  'ENTJ',
+  'ENTP',
+  'INFJ',
+  'INFP',
+  'ENFJ',
+  'ENFP',
+  'ISTJ',
+  'ISFJ',
+  'ESTJ',
+  'ESFJ',
+  'ISTP',
+  'ISFP',
+  'ESTP',
+  'ESFP',
+] as const;
+
 const GenerateFortuneInsightsInputSchema = z.object({
   birthdate: z
     .string()
+    .min(1, { message: 'birthdate cannot be empty' })
+    .regex(/^\d{4}-\d{2}-\d{2}$/, {
+      message: 'birthdate must be in YYYY-MM-DD format',
+    })
     .describe('The user birthdate in ISO format (YYYY-MM-DD).'),
-  mbti: z.string().describe('The user MBTI type.'),
+  mbti: z
+    .enum(MBTI_TYPES)
+    .describe('The user MBTI type (one of the 16 valid four-letter codes).'),
   gender: z.string().describe('User gender (e.g., 남성, 여성, 선택 안함).'),
   birthTime: z.string().describe('User birth time (e.g., 자시 (23:30 ~ 01:29), 모름).'),
   fortuneTypes: z


### PR DESCRIPTION
## Summary
- enforce `YYYY-MM-DD` date format and non-empty value
- restrict MBTI input to a literal enum of valid four‑letter types

## Testing
- `npm run typecheck` *(fails: Module not exported and other TS errors)*
- `npm test` *(fails: could not fetch Google Fonts while running Playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_68541b220c94832f8c50465e80f030e5