### PR TITLE
Refactor dashboard page into smaller components

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React, { useState } from "react";
+import UserProfile from "@/components/dashboard/UserProfile";
+import SajuFortuneForm from "@/components/dashboard/SajuFortuneForm";
+import MbtiFortuneForm from "@/components/dashboard/MbtiFortuneForm";
+import FortuneResult from "@/components/dashboard/FortuneResult";
+
+export default function DashboardPage() {
+  const [fortuneResult, setFortuneResult] = useState("");
+
+  const userName = "사용자";
+  const userEmail = "user@example.com";
+
+  const handleSajuSubmit = async (birthDate: string) => {
+    // TODO: Replace with real API call
+    setFortuneResult(`사주 결과 (${birthDate})`);
+  };
+
+  const handleMbtiSubmit = async (myMbti: string, partnerMbti: string) => {
+    // TODO: Replace with real API call
+    setFortuneResult(`MBTI 궁합 결과 (${myMbti} + ${partnerMbti})`);
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <UserProfile name={userName} email={userEmail} />
+      <SajuFortuneForm onSubmit={handleSajuSubmit} />
+      <MbtiFortuneForm onSubmit={handleMbtiSubmit} />
+      <FortuneResult result={fortuneResult} />
+    </div>
+  );
+}

--- a/src/components/dashboard/FortuneResult.tsx
+++ b/src/components/dashboard/FortuneResult.tsx
@@ -1,0 +1,17 @@
+"use client";
+import React from "react";
+
+interface FortuneResultProps {
+  result: string;
+}
+
+export default function FortuneResult({ result }: FortuneResultProps) {
+  if (!result) return null;
+
+  return (
+    <section>
+      <h4 className="text-lg font-semibold mb-2">운세 결과</h4>
+      <div>{result}</div>
+    </section>
+  );
+}

--- a/src/components/dashboard/MbtiFortuneForm.tsx
+++ b/src/components/dashboard/MbtiFortuneForm.tsx
@@ -1,0 +1,42 @@
+"use client";
+import React, { useState } from "react";
+
+interface MbtiFortuneFormProps {
+  onSubmit: (myMbti: string, partnerMbti: string) => void;
+}
+
+export default function MbtiFortuneForm({ onSubmit }: MbtiFortuneFormProps) {
+  const [myMbti, setMyMbti] = useState("");
+  const [partnerMbti, setPartnerMbti] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!myMbti || !partnerMbti) return;
+    onSubmit(myMbti, partnerMbti);
+  };
+
+  return (
+    <section>
+      <h3 className="text-lg font-semibold mb-2">MBTI 궁합 보기</h3>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          type="text"
+          placeholder="Your MBTI"
+          value={myMbti}
+          onChange={(e) => setMyMbti(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          placeholder="Partner's MBTI"
+          value={partnerMbti}
+          onChange={(e) => setPartnerMbti(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <button type="submit" className="px-3 py-1 bg-primary text-white rounded">
+          궁합 보기
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/dashboard/SajuFortuneForm.tsx
+++ b/src/components/dashboard/SajuFortuneForm.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React, { useState } from "react";
+
+interface SajuFortuneFormProps {
+  onSubmit: (birthDate: string) => void;
+}
+
+export default function SajuFortuneForm({ onSubmit }: SajuFortuneFormProps) {
+  const [birthDate, setBirthDate] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!birthDate) return;
+    onSubmit(birthDate);
+  };
+
+  return (
+    <section>
+      <h3 className="text-lg font-semibold mb-2">사주 운세 보기</h3>
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
+        <input
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          className="border rounded px-2 py-1"
+        />
+        <button type="submit" className="px-3 py-1 bg-primary text-white rounded">
+          결과 보기
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/dashboard/UserProfile.tsx
+++ b/src/components/dashboard/UserProfile.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+
+interface UserProfileProps {
+  name: string;
+  email: string;
+}
+
+export default function UserProfile({ name, email }: UserProfileProps) {
+  return (
+    <section className="space-y-1">
+      <h2 className="text-xl font-semibold">Welcome, {name}</h2>
+      <p className="text-sm text-muted-foreground">Email: {email}</p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add dashboard page and component folder
- split user profile, fortune forms, and result display into separate files

## Testing
- `npm run typecheck` *(fails: Module '@/lib/schemas' has no exported member 'FortuneFormValues', TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68541b610b00832f8bc104872525c662