### PR TITLE
Add SettingsScreen using Material3

### DIFF
--- a/android/src/main/java/ui/settings/SettingsScreen.kt
+++ b/android/src/main/java/ui/settings/SettingsScreen.kt
@@ -1,0 +1,96 @@
+package ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen(onLogoutClicked: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("설정") })
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            contentPadding = innerPadding,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            item {
+                Text(
+                    text = "계정",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
+                )
+            }
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.Person, contentDescription = null)
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(text = "프로필 수정")
+                }
+            }
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onLogoutClicked)
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.ExitToApp, contentDescription = null)
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(text = "로그아웃")
+                }
+            }
+            item { Divider() }
+            item {
+                Text(
+                    text = "알림",
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
+                )
+            }
+            item {
+                var pushEnabled by remember { mutableStateOf(false) }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "푸시 알림 받기",
+                        modifier = Modifier.weight(1f)
+                    )
+                    Switch(
+                        checked = pushEnabled,
+                        onCheckedChange = { pushEnabled = it }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsScreenPreview() {
+    MaterialTheme {
+        SettingsScreen(onLogoutClicked = {})
+    }
+}


### PR DESCRIPTION
## Summary
- implement a new `SettingsScreen` composable using Material 3 design components
- include preview for visualization

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68541b696824832f9433d28cdf8323cb