### PR TITLE
Add fortune loading skeleton

### DIFF
--- a/src/components/ui/FortuneSkeleton.tsx
+++ b/src/components/ui/FortuneSkeleton.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+import React from "react";
+
+export function FortuneSkeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("p-6 rounded-lg bg-muted/50 space-y-4", className)}
+      {...props}
+    >
+      <Skeleton className="h-6 w-2/5" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-11/12" />
+        <Skeleton className="h-4 w-10/12" />
+        <Skeleton className="h-4 w-9/12" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `FortuneSkeleton` component for loading state

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck` *(fails: several TS errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68541b2b4068832fb6a4278992e076f8