### PR TITLE
Implement streaming fortune generation

### DIFF
--- a/src/utils/genkit.ts
+++ b/src/utils/genkit.ts
@@ -1,0 +1,21 @@
+import { ai } from '@/ai/genkit';
+import { z } from 'zod';
+
+// Streaming fortune generation flow
+export const generateFortuneFlow = ai.defineFlow(
+  {
+    name: 'generateFortuneFlow',
+    inputSchema: z.object({ prompt: z.string() }),
+    streamSchema: z.string(),
+  },
+  async function* ({ prompt }) {
+    const { stream } = ai.generateStream({
+      prompt: `Tell a fortune based on this: ${prompt}`,
+      model: 'google/gemini-pro',
+    });
+
+    for await (const chunk of stream) {
+      yield chunk.text;
+    }
+  }
+);


### PR DESCRIPTION
## Summary
- add `src/utils/genkit.ts` defining `generateFortuneFlow` as a streaming flow

## Testing
- `npm run typecheck` *(fails: Module has no exported member 'FortuneFormValues', etc)*
- `npm run lint` *(interactive prompt prevents execution)*

------
https://chatgpt.com/codex/tasks/task_e_68541b198c18832f960f830d8e8b16f4