### PR TITLE
Add dream interpretation search page

### DIFF
--- a/src/app/interactive/dream/page.tsx
+++ b/src/app/interactive/dream/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { useState } from 'react';
+import AppHeader from '@/components/AppHeader';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { FortuneCompassIcon } from '@/components/icons/fortune-compass-icon';
+import type { Dream } from '@/data/model/Dream';
+import { DreamRepositoryImpl } from '@/data/repository/DreamRepositoryImpl';
+
+const POPULAR_KEYWORDS = ['용', '이빨', '물', '돈'];
+const repo = new DreamRepositoryImpl();
+
+export default function DreamPage() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Dream[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSearch = async (q: string) => {
+    const search = q.trim();
+    setQuery(q);
+    if (!search) {
+      setResults([]);
+      return;
+    }
+    setIsLoading(true);
+    const res = await repo.searchByKeyword(search);
+    // 작은 지연을 주어 로딩 상태를 보여줌
+    setTimeout(() => {
+      setResults(res);
+      setIsLoading(false);
+    }, 300);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch(query);
+    }
+  };
+
+  const handleBadgeClick = (keyword: string) => {
+    setQuery(keyword);
+    handleSearch(keyword);
+  };
+
+  const getBadgeClass = (type: Dream['type']) => {
+    switch (type) {
+      case '길몽':
+        return 'bg-blue-100 text-blue-800';
+      case '흉몽':
+        return 'bg-red-100 text-red-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  return (
+    <>
+      <AppHeader title="꿈해몽" />
+      <div className="min-h-screen bg-background text-foreground p-4 pb-32 space-y-4">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="꿈에서 본 키워드를 입력하세요 (예: 용, 이빨)"
+          className="text-lg py-6"
+        />
+        <div className="flex flex-wrap gap-2">
+          {POPULAR_KEYWORDS.map((keyword) => (
+            <Badge
+              key={keyword}
+              onClick={() => handleBadgeClick(keyword)}
+              className="cursor-pointer"
+            >
+              {keyword}
+            </Badge>
+          ))}
+        </div>
+
+        {isLoading && (
+          <div className="flex justify-center py-10">
+            <FortuneCompassIcon className="h-12 w-12 animate-spin text-primary" />
+          </div>
+        )}
+
+        {!isLoading && results.length > 0 && (
+          <div className="space-y-3">
+            <p className="text-sm">'{query}'에 대한 {results.length}개의 꿈풀이가 있습니다.</p>
+            {results.map((dream) => (
+              <Card key={dream.id} className="hover:shadow-md transition-shadow">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base flex items-center justify-between">
+                    <span>{dream.title}</span>
+                    <Badge className={getBadgeClass(dream.type)}>{dream.type}</Badge>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <p className="text-sm text-muted-foreground">{dream.interpretation}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && query && results.length === 0 && (
+          <p className="text-muted-foreground">검색 결과가 없습니다.</p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/data/model/Dream.ts
+++ b/src/data/model/Dream.ts
@@ -1,0 +1,7 @@
+export interface Dream {
+  id: number;
+  title: string;
+  interpretation: string;
+  type: '길몽' | '흉몽' | '보통';
+  keywords: string[];
+}

--- a/src/data/repository/DreamRepository.ts
+++ b/src/data/repository/DreamRepository.ts
@@ -1,0 +1,5 @@
+import type { Dream } from '../model/Dream';
+
+export interface DreamRepository {
+  searchByKeyword(keyword: string): Promise<Dream[]>;
+}

--- a/src/data/repository/DreamRepositoryImpl.ts
+++ b/src/data/repository/DreamRepositoryImpl.ts
@@ -1,0 +1,51 @@
+import type { Dream } from '../model/Dream';
+import type { DreamRepository } from './DreamRepository';
+
+const DREAMS: Dream[] = [
+  {
+    id: 1,
+    title: '용이 하늘로 올라가는 꿈',
+    interpretation: '큰 성공이나 명예를 얻을 수 있는 길몽을 뜻합니다.',
+    type: '길몽',
+    keywords: ['용', '승천'],
+  },
+  {
+    id: 2,
+    title: '이빨이 빠지는 꿈',
+    interpretation: '가족이나 가까운 사람과의 이별을 의미할 수 있습니다.',
+    type: '흉몽',
+    keywords: ['이빨', '치아', '빠짐'],
+  },
+  {
+    id: 3,
+    title: '물에서 헤엄치는 꿈',
+    interpretation: '새로운 기회가 찾아오거나 재물운이 상승함을 암시합니다.',
+    type: '보통',
+    keywords: ['물', '헤엄'],
+  },
+  {
+    id: 4,
+    title: '높은 곳에서 떨어지는 꿈',
+    interpretation: '계획에 차질이 생기거나 좌절을 겪을 수 있음을 경고합니다.',
+    type: '흉몽',
+    keywords: ['떨어짐', '낙하'],
+  },
+  {
+    id: 5,
+    title: '돈을 줍는 꿈',
+    interpretation: '예상치 못한 금전적 이득이 찾아올 수 있습니다.',
+    type: '길몽',
+    keywords: ['돈', '재물'],
+  },
+];
+
+export class DreamRepositoryImpl implements DreamRepository {
+  async searchByKeyword(keyword: string): Promise<Dream[]> {
+    const q = keyword.trim();
+    if (!q) return [];
+    return DREAMS.filter(
+      (d) =>
+        d.title.includes(q) || d.keywords.some((k) => k.includes(q))
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `Dream` model and repository
- add local dream data with a simple search interface
- new `/interactive/dream` page with search UI using project styles

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855280276d0832f950678f9737972ea