### PR TITLE
Improve Playwright stability

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  timeout: 60 * 1000,
+  expect: {
+    timeout: 60 * 1000,
+  },
   use: {
     baseURL: process.env.CI ? 'http://localhost:3000' : 'http://localhost:9002',
     trace: 'on-first-retry',

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -4,6 +4,7 @@ import { OnboardingNamePage } from './pages/OnboardingNamePage';
 test.describe('운세 앱 기본 동작 테스트', () => {
   test('메인 페이지 로딩 및 기본 요소 확인', async ({ page }) => {
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
     
     // 페이지 타이틀 확인
     await expect(page).toHaveTitle(/운세 탐험/);
@@ -16,6 +17,8 @@ test.describe('운세 앱 기본 동작 테스트', () => {
   test('이름 입력 및 다음 단계 진행', async ({ page }) => {
     const namePage = new OnboardingNamePage(page);
     await namePage.goto();
+    // 필요한 경우 여기서 디버깅용 일시 중지를 사용할 수 있습니다.
+    // await page.pause();
     await namePage.enterName('테스트 사용자');
     await namePage.submitName();
 

--- a/tests/mcp-integration.spec.ts
+++ b/tests/mcp-integration.spec.ts
@@ -5,16 +5,23 @@ test.describe('MCP 통합 테스트', () => {
   // 헬퍼 함수: 프로필 설정 완료까지 진행
   const completeProfileSetup = async (page: Page) => {
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
     
     // 1단계: 이름 입력
-    await page.fill('input[name="name"]', 'MCP 테스트 사용자');
-    await page.click('text=다음');
+    const nameInput = page.locator('input[name="name"]');
+    const nextBtn = page.getByRole('button', { name: '다음' });
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill('MCP 테스트 사용자');
+    await expect(nextBtn).toBeEnabled();
+    await nextBtn.click();
+    await page.waitForLoadState('networkidle');
     
     // 2단계: 생년월일 선택
     await page.selectOption('select:near(:text("년"))', '1990');
     await page.selectOption('select:near(:text("월"))', '5');
     await page.selectOption('select:near(:text("일"))', '15');
-    await page.click('text=다음');
+    await nextBtn.click();
+    await page.waitForLoadState('networkidle');
     
     // 3단계: 성별, MBTI, 출생시간 선택
     await page.selectOption('select:near(:text("성별"))', '남성');
@@ -38,7 +45,10 @@ test.describe('MCP 통합 테스트', () => {
     });
 
     // 완료 버튼 클릭
-    await page.click('text=완료');
+    const completeBtn = page.getByRole('button', { name: '완료' });
+    await expect(completeBtn).toBeVisible();
+    await completeBtn.click();
+    await page.waitForLoadState('networkidle');
 
     // 네트워크 응답 확인
     await saveResponsePromise;

--- a/tests/pages/OnboardingNamePage.ts
+++ b/tests/pages/OnboardingNamePage.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 
 export class OnboardingNamePage {
   readonly page: Page;
@@ -13,13 +13,18 @@ export class OnboardingNamePage {
 
   async goto() {
     await this.page.goto('/');
+    await this.page.waitForLoadState('networkidle');
   }
 
   async enterName(name: string) {
+    await expect(this.nameInput).toBeVisible();
     await this.nameInput.fill(name);
   }
 
   async submitName() {
+    await expect(this.nextButton).toBeEnabled();
     await this.nextButton.click();
+    // 네트워크 요청이 끝날 때까지 대기
+    await this.page.waitForLoadState('networkidle');
   }
 }


### PR DESCRIPTION
## Summary
- strengthen waits and selector visibility for Onboarding name page
- wait for network idle in MCP profile test
- show optional page.pause usage in example tests
- increase Playwright test and expect timeouts

## Testing
- `npm test -- --list`
- `npx playwright test tests/example.spec.ts --workers=1` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685538ebd7e8832fba5d40924c7ed811