### PR TITLE
Add interactive face reading

### DIFF
--- a/src/ai/flows/generate-face-reading-insights.ts
+++ b/src/ai/flows/generate-face-reading-insights.ts
@@ -1,0 +1,38 @@
+'use server'
+
+import {ai} from '@/ai/genkit'
+import {z} from 'genkit'
+
+export const FaceReadingInputSchema = z.object({
+  labels: z.array(z.string()).describe('Array of face-reading feature labels')
+})
+export type FaceReadingInput = z.infer<typeof FaceReadingInputSchema>
+
+export const FaceReadingOutputSchema = z.object({
+  interpretation: z.string().describe('Comprehensive face reading analysis')
+})
+export type FaceReadingOutput = z.infer<typeof FaceReadingOutputSchema>
+
+const prompt = ai.definePrompt({
+  name: 'faceReadingPrompt',
+  input: {schema: FaceReadingInputSchema},
+  output: {schema: FaceReadingOutputSchema},
+  config: {responseMimeType: 'application/json'},
+  prompt: `당신은 수천 년의 지혜를 현대적으로 해석하는 AI 관상가입니다. 사용자의 얼굴에서 {{{labels}}}와 같은 특징들이 발견되었습니다. 이 특징들을 유기적으로 연결하여 사용자의 타고난 성격, 대인관계 스타일, 잠재된 재능에 대해 하나의 완성된 이야기로 풀어주세요. '넓은 이마는 당신의 지적 호기심을, 곧은 콧대는 강한 추진력을 상징하며, 이 두 가지가 만나 큰 성공을 이룰 수 있습니다' 와 같이 긍정적이고 자신감을 주는 방향으로 해석해주세요.`
+})
+
+const faceReadingFlow = ai.defineFlow({
+  name: 'faceReadingFlow',
+  inputSchema: FaceReadingInputSchema,
+  outputSchema: FaceReadingOutputSchema,
+}, async input => {
+  const {output} = await prompt(input)
+  if (!output) {
+    return {interpretation: '관상 해석을 생성하지 못했습니다.'}
+  }
+  return output
+})
+
+export async function generateFaceReadingInsights(input: FaceReadingInput): Promise<FaceReadingOutput> {
+  return faceReadingFlow(input)
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,17 @@
 
 "use server";
 
-import { generateFortuneInsights, type GenerateFortuneInsightsInput, type GenerateFortuneInsightsOutput as AIOutputType, type SajuDataType } from "@/ai/flows/generate-fortune-insights";
+import {
+  generateFortuneInsights,
+  type GenerateFortuneInsightsInput,
+  type GenerateFortuneInsightsOutput as AIOutputType,
+  type SajuDataType,
+} from "@/ai/flows/generate-fortune-insights";
+import {
+  generateFaceReadingInsights,
+  type FaceReadingInput,
+  type FaceReadingOutput,
+} from "@/ai/flows/generate-face-reading-insights";
 import type { FortuneFormValues } from "@/lib/schemas";
 import { format } from "date-fns";
 
@@ -11,10 +21,20 @@ export interface FormattedFortuneOutput {
   sajuData?: SajuDataType; // Added SajuDataType
 }
 
+export interface FaceReadingResult {
+  interpretation: string;
+}
+
 export interface ActionResult {
   data?: FormattedFortuneOutput;
   error?: string;
   input?: GenerateFortuneInsightsInput;
+}
+
+export interface FaceReadingActionResult {
+  data?: FaceReadingResult;
+  error?: string;
+  input?: FaceReadingInput;
 }
 
 export async function getFortuneAction(
@@ -63,5 +83,19 @@ export async function getFortuneAction(
     console.error("Error generating fortune:", e);
     const errorMessage = e instanceof Error ? e.message : "알 수 없는 오류가 발생했습니다.";
     return { error: `운세 생성 중 오류가 발생했습니다: ${errorMessage}` };
+  }
+}
+
+export async function getFaceReadingAction(
+  labels: string[]
+): Promise<FaceReadingActionResult> {
+  try {
+    const input: FaceReadingInput = { labels };
+    const result: FaceReadingOutput = await generateFaceReadingInsights(input);
+    return { data: result, input };
+  } catch (e) {
+    console.error('Error generating face reading:', e);
+    const message = e instanceof Error ? e.message : '알 수 없는 오류가 발생했습니다.';
+    return { error: message };
   }
 }

--- a/src/app/physiognomy/page.tsx
+++ b/src/app/physiognomy/page.tsx
@@ -1,79 +1,116 @@
 "use client";
 
-import React, { useState } from "react";
-import Image from "next/image";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { FortuneCompassIcon } from "@/components/icons/fortune-compass-icon";
 import AppHeader from "@/components/AppHeader";
+import type { FaceReadingResult } from "@/app/actions";
 
-interface AnalysisResult {
-  part: string;
-  text: string;
+// Optional: MediaPipe FaceMesh imports. These are lightweight and run on-device.
+import { FaceMesh } from "@mediapipe/face_mesh";
+import { Camera } from "@mediapipe/camera_utils";
+
+interface Landmark { x: number; y: number; }
+
+function distance(a: Landmark, b: Landmark) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.hypot(dx, dy);
+}
+
+function calculateAngle(a: Landmark, b: Landmark, c: Landmark) {
+  const ab = { x: b.x - a.x, y: b.y - a.y };
+  const cb = { x: b.x - c.x, y: b.y - c.y };
+  const dot = ab.x * cb.x + ab.y * cb.y;
+  const abMag = Math.hypot(ab.x, ab.y);
+  const cbMag = Math.hypot(cb.x, cb.y);
+  const cosine = dot / (abMag * cbMag);
+  return (Math.acos(cosine) * 180) / Math.PI;
+}
+
+function generateLabels(landmarks: Landmark[]): string[] {
+  const labels: string[] = [];
+  const browDistance = distance(landmarks[65], landmarks[295]);
+  const faceWidth = distance(landmarks[234], landmarks[454]);
+  const ratio = browDistance / faceWidth;
+  if (ratio > 0.3) labels.push("forehead_wide");
+
+  const lipAngle = calculateAngle(landmarks[61], landmarks[0], landmarks[291]);
+  if (lipAngle < 165) labels.push("lips_upturned");
+
+  const noseLength = distance(landmarks[1], landmarks[2]);
+  const faceLength = distance(landmarks[10], landmarks[152]);
+  if (noseLength / faceLength > 0.25) labels.push("nose_straight");
+
+  return labels;
 }
 
 export default function ImagePhysiognomyScreen() {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [results, setResults] = useState<AnalysisResult[] | null>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [labels, setLabels] = useState<string[]>([]);
+  const [result, setResult] = useState<FaceReadingResult | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setSelectedFile(file);
-      setPreviewUrl(URL.createObjectURL(file));
-      setResults(null);
-    }
-  };
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const faceMesh = new FaceMesh({
+      locateFile: file => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/${file}`,
+    });
+    faceMesh.setOptions({ maxNumFaces: 1, refineLandmarks: true });
+    faceMesh.onResults(res => {
+      if (!res.multiFaceLandmarks || !res.multiFaceLandmarks[0]) return;
+      const lm = res.multiFaceLandmarks[0].map(p => ({ x: p.x, y: p.y }));
+      const newLabels = generateLabels(lm);
+      setLabels(newLabels);
+    });
+
+    const camera = new Camera(video, {
+      onFrame: async () => {
+        await faceMesh.send({ image: video });
+      },
+      width: 640,
+      height: 480,
+    });
+    camera.start();
+  }, []);
 
   const handleAnalyze = async () => {
-    if (!selectedFile) return;
-    setIsAnalyzing(true);
-
-    // Simulate analysis delay
-    setTimeout(() => {
-      setIsAnalyzing(false);
-      setResults([
-        { part: "눈썹", text: "눈썹이 진하여 결단력이 돋보입니다." },
-        { part: "코", text: "코가 오똑해 재물운이 좋습니다." },
-        { part: "입", text: "입술이 도톰해 인간관계가 원만합니다." },
-      ]);
-    }, 2000);
+    if (!labels.length) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/face-reading", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ labels }),
+      });
+      if (res.ok) {
+        const data: FaceReadingResult = await res.json();
+        setResult(data);
+      }
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className="min-h-screen bg-background text-foreground pb-20">
       <AppHeader title="AI 관상" />
-      
-      <div className="flex flex-col items-center p-6 space-y-6">
-      <input type="file" accept="image/*" onChange={handleFileChange} className="w-full max-w-md" />
-
-      {previewUrl && (
-        <div className="relative w-full max-w-md">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={previewUrl} alt="선택한 이미지" className="w-full h-auto rounded-md" />
-          {isAnalyzing && (
-            <div className="absolute inset-0 flex items-center justify-center bg-background/80 rounded-md">
-              <FortuneCompassIcon className="h-12 w-12 text-primary animate-spin" />
-            </div>
-          )}
-        </div>
-      )}
-
-      {previewUrl && (
-        <Button onClick={handleAnalyze} className="w-full max-w-md">관상 분석하기</Button>
-      )}
-
-      {results && (
-        <div className="w-full max-w-md space-y-2">
-          {results.map((r) => (
-            <div key={r.part} className="border rounded-md p-3">
-              <h3 className="font-semibold mb-1">{r.part}</h3>
-              <p className="text-sm text-muted-foreground">{r.text}</p>
-            </div>
-          ))}
-        </div>
-      )}
+      <div className="flex flex-col items-center p-6 space-y-4">
+        <video ref={videoRef} className="rounded-md" autoPlay playsInline width={320} height={240} />
+        <canvas ref={canvasRef} width={320} height={240} className="hidden" />
+        <Button onClick={handleAnalyze} disabled={loading || labels.length === 0} className="w-full max-w-md">
+          {loading ? "분석 중..." : "관상 분석하기"}
+        </Button>
+        {labels.length > 0 && (
+          <div className="text-sm text-muted-foreground">추출된 특징: {labels.join(", ")}</div>
+        )}
+        {result && (
+          <div className="border rounded-md p-4 w-full max-w-md">
+            <p className="text-sm whitespace-pre-wrap">{result.interpretation}</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/api/face-reading.ts
+++ b/src/pages/api/face-reading.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getFaceReadingAction } from '@/app/actions'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+
+  const labels = req.body?.labels
+  if (!Array.isArray(labels)) {
+    res.status(400).json({ error: 'Invalid labels' })
+    return
+  }
+
+  const result = await getFaceReadingAction(labels)
+  if (result.error || !result.data) {
+    res.status(500).json({ error: result.error || 'Failed to generate interpretation' })
+    return
+  }
+
+  res.status(200).json(result.data)
+}


### PR DESCRIPTION
## Summary
- add backend flow to interpret face landmarks via GPT-4o mini
- expose `/api/face-reading` endpoint
- implement on-device face reading page using MediaPipe
- wire up new actions for physiognomy page

## Testing
- `npm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_6855608cbd3c832fa7a313940628ea1c