### PR TITLE
Fix syntax errors across Dart code

### DIFF
--- a/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_enhanced_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_enhanced_page.dart
@@ -229,7 +229,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
             child: Text(
               '성격 운세')
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
                 background: Paint()
                   ..shader = LinearGradient(
                     colors: [AppColors.primary, AppColors.secondary])
@@ -445,7 +445,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
               Text(
                 'MBTI 유형을 선택하세요')
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               SizedBox(height: AppSpacing.spacing2))
               Text(
@@ -491,7 +491,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
                           Text(
                             '${data.mbtiType} 타입')
                             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold),))
+                              fontWeight: FontWeight.bold))
                             ),
                         ])
                       ),
@@ -523,7 +523,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
         Text(
           '성향 세부 조정')
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.bold),))
+            fontWeight: FontWeight.bold))
           ))
         SizedBox(height: AppSpacing.spacing4))
         ...dimensions.map((dimension) {
@@ -594,7 +594,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '추가 정보를 입력하세요')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing2))
           Text(
@@ -609,7 +609,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '혈액형')
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing4))
           BloodTypeCardSelector(
@@ -627,7 +627,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '성격 특성 (최대 5개)')
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing4))
           PersonalityTraitsChips(
@@ -645,7 +645,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '생활 패턴')
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing4))
           _buildLifePatternSelector(data))
@@ -655,7 +655,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '스트레스 대응 방식')
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing4))
           _buildStressResponseSelector(data))
@@ -822,7 +822,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '분석하고 싶은 항목을 선택하세요')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing2))
           Text(
@@ -858,7 +858,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '궁금한 점이 있으신가요?')
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing4))
           TextField(
@@ -896,7 +896,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             '성격 분석 준비 완료!')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing2))
           Text(
@@ -974,7 +974,7 @@ class _PersonalityFortuneEnhancedPageState extends ConsumerState<PersonalityFort
           Text(
             title)
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           SizedBox(height: AppSpacing.spacing2))
           ...items.map((item) => Padding(

--- a/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_optimized_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_optimized_page.dart
@@ -333,7 +333,7 @@ class _PersonalityFortuneOptimizedPageState
             Text(
               '성격 기반 운세')
               style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ))
             SizedBox(height: AppSpacing.spacing2))
             Text(
@@ -360,7 +360,7 @@ class _PersonalityFortuneOptimizedPageState
         Text(
           title)
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.bold),))
+            fontWeight: FontWeight.bold))
           ))
         SizedBox(height: AppSpacing.spacing3))
         child)
@@ -565,7 +565,7 @@ class _PersonalityFortuneOptimizedPageState
               child: Text(
                 '운세 확인하기')
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: AppColors.textPrimaryDark),))
+                  color: AppColors.textPrimaryDark))
                   fontWeight: FontWeight.bold)
                 ))
           ))

--- a/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_result_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_result_page.dart
@@ -141,7 +141,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                 Text(
                   '${widget.personalityData.mbtiType} 성격 분석',
                   style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
                 Text(
                   widget.personalityData.name ?? '')
@@ -224,7 +224,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                         Text(
                           '$overallScore')
                           style: Theme.of(context).textTheme.displayLarge?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                             fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                           ))
                         ))
@@ -242,7 +242,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                 Text(
                   result?['summary'] ?? '',
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    height: 1.6),))
+                    height: 1.6))
                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                   ))
                   textAlign: TextAlign.center)
@@ -272,7 +272,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '핵심 성격 특성')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -332,13 +332,13 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                   Text(
                     '오늘의 메시지')
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                     ))
                   SizedBox(height: AppSpacing.spacing2))
                   Text(
                     (result!['recommendations'] as List<dynamic>).first,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      height: 1.6),))
+                      height: 1.6))
                       fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                     ))
                     textAlign: TextAlign.center)
@@ -377,7 +377,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                     Text(
                       'MBTI 상세 분석')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                       ))
                   ])
                 ),
@@ -438,7 +438,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '성격 특성 분포')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -500,7 +500,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                     Text(
                       '소통 스타일')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                       ))
                   ])
                 ),
@@ -536,7 +536,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '궁합이 좋은 유형')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -607,7 +607,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '인간관계 조언')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -668,7 +668,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                     Text(
                       '업무 스타일')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                       ))
                   ])
                 ),
@@ -704,7 +704,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '추천 직업')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -740,7 +740,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                                 Text(
                                   career['title'] ?? '',
                                   style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                                    fontWeight: FontWeight.bold),))
+                                    fontWeight: FontWeight.bold))
                                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                                   ))
                                 ))
@@ -790,7 +790,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '경력 개발 조언')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -853,7 +853,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                 Text(
                   '성장 잠재력')
                   style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
                 SizedBox(height: AppSpacing.spacing2))
                 Row(
@@ -908,14 +908,14 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                                 Text(
                                   area['title'] ?? '',
                                   style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                                    fontWeight: FontWeight.bold),))
+                                    fontWeight: FontWeight.bold))
                                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                                   ))
                                 ))
                                 Text(
                                   area['priority'] ?? '',
                                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                    color: AppColors.primary),))
+                                    color: AppColors.primary))
                                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                                   ))
                                 ))
@@ -928,7 +928,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         area['description'] ?? '',
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          height: 1.5),))
+                          height: 1.5))
                           fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize + fontSize)
                         ))
                       ))
@@ -990,7 +990,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
                       Text(
                         '추천 일일 습관')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -1154,7 +1154,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
               Text(
                 '강점')
                 style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
             ])
           ),
@@ -1207,7 +1207,7 @@ class _PersonalityFortuneResultPageState extends ConsumerState<PersonalityFortun
               Text(
                 '약점')
                 style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
             ])
           ),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/talisman_steps/talisman_generation_step.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/talisman_steps/talisman_generation_step.dart
@@ -22,7 +22,7 @@ class TalismanGenerationStep extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<TalismanGenerationStep> createState() => _TalismanGenerationStepState();,
+  ConsumerState<TalismanGenerationStep> createState() => _TalismanGenerationStepState();
 }
 
 class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
@@ -41,14 +41,14 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
     
     // Start generation process
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _generateTalisman();,
-});,
+      _generateTalisman();
+});
 }
 
   @override
   void dispose() {
     _animationController.dispose();
-    super.dispose();,
+    super.dispose();
 }
 
   Future<void> _generateTalisman() async {
@@ -59,9 +59,9 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
     if (state.selectedType == null) {
       setState(() {
         _isGenerating = false;
-        _statusMessage = '부적 유형이 선택되지 않았습니다.';,
-});
-      return;,
+        _statusMessage = '부적 유형이 선택되지 않았습니다.';
+      });
+      return;
 }
     
     // Simulate progress updates
@@ -135,16 +135,16 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
         
         // Complete after a short delay
         await Future.delayed(const Duration(milliseconds: 500));
-        widget.onComplete(result);,
+        widget.onComplete(result);
 } else {
-        throw Exception(response['error'] ?? '부적 생성에 실패했습니다');,
+        throw Exception(response['error'] ?? '부적 생성에 실패했습니다');
 }
     } catch (e) {
       setState(() {
         _isGenerating = false;
-        _statusMessage = '오류가 발생했습니다: ${e.toString()}';,
-});
-      HapticUtils.errorNotification();,
+        _statusMessage = '오류가 발생했습니다: ${e.toString()}';
+      });
+      HapticUtils.errorNotification();
 }
   }
 
@@ -152,7 +152,7 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
     setState(() {
       _progress = progress;
       _statusMessage = message;,
-});,
+});
 }
 
   @override
@@ -212,7 +212,7 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
                                         progress: _progress,
                                         color: state.selectedType!.gradientColors[0],
                                       ),
-                                  ));,
+                                  ));
 },
                             ),
                             
@@ -310,7 +310,7 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
                   child: const Text('다시 만들기'),
             ],
           ),
-      ));,
+      ));
 }
 }
 
@@ -359,7 +359,7 @@ class _MagicCirclePainter extends CustomPainter {
         Offset(x, y),
         4,
         paint..style = PaintingStyle.fill,
-      );,
+      );
 }
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/tarot_deck_selection_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/tarot_deck_selection_page.dart
@@ -20,7 +20,7 @@ class TarotDeckSelectionPage extends ConsumerStatefulWidget {
   }) : super(key: key);
 
   @override
-  ConsumerState<TarotDeckSelectionPage> createState() => _TarotDeckSelectionPageState();,
+  ConsumerState<TarotDeckSelectionPage> createState() => _TarotDeckSelectionPageState();
 }
 
 class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
@@ -41,20 +41,20 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
       parent: _animationController,
       curve: Curves.easeIn,
     );
-    _animationController.forward();,
+    _animationController.forward();
 }
 
   @override
   void dispose() {
     _animationController.dispose();
-    super.dispose();,
+    super.dispose();
 }
 
   void _selectDeck(String deckId) {
     HapticFeedback.lightImpact();
     setState(() {
       _tempSelectedDeckId = deckId;,
-});,
+});
 }
   
   void _confirmSelection() async {
@@ -76,7 +76,7 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
           if (widget.spreadType != null) 'spreadType': widget.spreadType!,
           if (widget.initialQuestion != null) 'question': widget.initialQuestion!,
         },
-      );,
+      );
 }
   }
 
@@ -189,7 +189,7 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
                   icon: const Icon(Icons.check, color: Colors.white),
               ),
         ),
-      ));,
+      ));
 }
 
   Widget _buildSectionTitle(String title, double fontScale) {
@@ -216,7 +216,7 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
             color: Colors.white,
           ),
       ],
-    );,
+    );
 }
 
   Widget _buildExperienceLevelSection(ThemeData theme, double fontScale) {
@@ -255,14 +255,14 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
                 selected: isSelected,
                 onSelected: (selected) {
                   if (selected) {
-                    ref.read(tarotExperienceLevelProvider.notifier).setExperienceLevel(level);,
+                    ref.read(tarotExperienceLevelProvider.notifier).setExperienceLevel(level);
 }
                 },
                 selectedColor: level.color.withValues(alpha: 0.3),
-                backgroundColor: Colors.white.withValues(alpha: 0.1));,
+                backgroundColor: Colors.white.withValues(alpha: 0.1));
 }).toList(),
         ],
-      ));,
+      ));
 }
 
   Widget _buildDeckGrid(
@@ -288,9 +288,9 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
           isSelected: deck.id == (_tempSelectedDeckId ?? currentDeckId),
           isMostUsed: deck.id == mostUsedDeckId,
           fontScale: fontScale,
-        );,
+        );
 },
-    );,
+    );
 }
 
   Widget _buildDeckCard(
@@ -412,7 +412,7 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
                   ),
           ),
       
-    );,
+    );
 }
 
   Widget _buildDeckPreview(TarotDeck deck) {
@@ -431,7 +431,7 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
           Transform.rotate(
             angle: 0.2),
                   child: _buildPreviewCard(deck, 2)) else ...[
-          _buildPreviewCard(deck, 0)    );,
+          _buildPreviewCard(deck, 0)    );
 }
 
   Widget _buildPreviewCard(TarotDeck deck, int index) {
@@ -464,9 +464,9 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
                   color: Colors.white.withValues(alpha: 0.5),
                   size: 30,
                 ),
-            );,
+            );
 },
-        ));,
+        ));
 }
 
   Widget _buildTag(String text, Color color, double fontScale) {
@@ -485,6 +485,6 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
           fontSize: 10 * fontScale,
           color: Colors.white),
                   fontWeight: FontWeight.w500)
-        ));,
+        ));
 }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/tarot_enhanced_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/tarot_enhanced_page.dart
@@ -82,27 +82,27 @@ class _TarotEnhancedPageState extends ConsumerState<TarotEnhancedPage>
   void dispose() {
     _heroController.dispose();
     _fadeController.dispose();
-    super.dispose();,
+    super.dispose();
 }
 
   void _selectSpread(TarotSpreadType spread) {
     setState(() {
       _selectedSpread = spread;
       _showSpreadSelection = false;,
-});,
+});
 }
 
   void _backToSpreadSelection() {
     setState(() {
       _showSpreadSelection = true;
       _selectedSpread = null;,
-});,
+});
 }
 
   void _proceedFromQuestion() {
     setState(() {
       _showQuestionInput = false;,
-});,
+});
 }
 
   @override
@@ -141,7 +141,7 @@ class _TarotEnhancedPageState extends ConsumerState<TarotEnhancedPage>
                       fontScale: fontScale)
                     ),
             ),
-      ));,
+      ));
 }
 }
 
@@ -160,7 +160,7 @@ class _MysticalBackground extends StatelessWidget {
       ),
       child: CustomPaint(
         painter: _MysticalParticlesPainter(),
-        child: Container());,
+        child: Container());
 }
 }
 
@@ -177,7 +177,7 @@ class _MysticalParticlesPainter extends CustomPainter {
       final y = random.nextDouble() * size.height;
       final radius = random.nextDouble() * 3 + 1;
       
-      canvas.drawCircle(Offset(x, y), radius, paint);,
+      canvas.drawCircle(Offset(x, y), radius, paint);
 }
   }
 
@@ -197,7 +197,7 @@ class _QuestionInputView extends ConsumerStatefulWidget {
 });
 
   @override
-  ConsumerState<_QuestionInputView> createState() => _QuestionInputViewState();,
+  ConsumerState<_QuestionInputView> createState() => _QuestionInputViewState();
 }
 
 class _QuestionInputViewState extends ConsumerState<_QuestionInputView> {
@@ -206,7 +206,7 @@ class _QuestionInputViewState extends ConsumerState<_QuestionInputView> {
   @override
   void dispose() {
     _questionController.dispose();
-    super.dispose();,
+    super.dispose();
 }
 
   void _proceed() {
@@ -214,7 +214,7 @@ class _QuestionInputViewState extends ConsumerState<_QuestionInputView> {
     // Navigate to animated tarot flow
     context.push('/interactive/tarot/animated-flow', extra: {
       'question': _questionController.text.isEmpty ? '오늘의 운세를 봐주세요' : _questionController.text)
-      'heroTag': 'daily-fortune-${DateTime.now().millisecondsSinceEpoch}');,
+      'heroTag': 'daily-fortune-${DateTime.now().millisecondsSinceEpoch}');
 }
 
   @override
@@ -354,7 +354,7 @@ class _QuestionInputViewState extends ConsumerState<_QuestionInputView> {
                     context.push('/interactive/tarot', extra: {
                       'question': _questionController.text.isEmpty ? '오늘의 운세를 봐주세요' : _questionController.text)
                       'skipSpreadSelection': true,  // Skip spread selection, let user select cards first,
-});,
+});
 },
                   gradient: LinearGradient(
                     colors: [
@@ -375,7 +375,7 @@ class _QuestionInputViewState extends ConsumerState<_QuestionInputView> {
                           ),
                     ),
                 ),
-          ));,
+          ));
 }
 }
 
@@ -432,7 +432,7 @@ class _SpreadSelectionView extends StatelessWidget {
                   onTap: () => onSpreadSelected(spread),
               fontScale: fontScale,
             ))),
-    );,
+    );
 }
 }
 
@@ -458,7 +458,7 @@ class _TarotHeaderCard extends StatelessWidget {
           Icons.auto_awesome,
           size: 56),
                   color: theme.colorScheme.primary)
-        ));,
+        ));
 }
 }
 
@@ -484,7 +484,7 @@ class _SpreadOptionCard extends StatelessWidget {
       case TarotSpreadType.relationship:
         return _buildRelationshipPreview();
       case TarotSpreadType.decision:
-        return _buildDecisionPreview();,
+        return _buildDecisionPreview();
 }
   }
 
@@ -498,7 +498,7 @@ class _SpreadOptionCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(4),
           border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
       
-    );,
+    );
 }
 
   Widget _buildThreeCardPreview() {
@@ -513,7 +513,7 @@ class _SpreadOptionCard extends StatelessWidget {
             color: Colors.purple.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(4),
             border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
-        ))));,
+        ))));
 }
 
   Widget _buildCelticCrossPreview() {
@@ -550,7 +550,7 @@ class _SpreadOptionCard extends StatelessWidget {
               borderRadius: BorderRadius.circular(2),
               border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
           ))
-    );,
+    );
 }
 
   Widget _buildRelationshipPreview() {
@@ -575,7 +575,7 @@ class _SpreadOptionCard extends StatelessWidget {
             color: Colors.pink.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(4),
             border: Border.all(color: Colors.pink.withValues(alpha: 0.5)),
-        ));,
+        ));
 }
 
   Widget _buildDecisionPreview() {
@@ -611,7 +611,7 @@ class _SpreadOptionCard extends StatelessWidget {
                 borderRadius: BorderRadius.circular(4),
                 border: Border.all(color: Colors.orange.withValues(alpha: 0.5)),
             ),
-    );,
+    );
 }
 
   @override
@@ -676,7 +676,7 @@ class _SpreadOptionCard extends StatelessWidget {
               Icons.arrow_forward_ios),
                   size: 20),
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
-        ));,
+        ));
 }
 }
 
@@ -692,7 +692,7 @@ class _TarotReadingView extends ConsumerStatefulWidget {
 });
 
   @override
-  ConsumerState<_TarotReadingView> createState() => _TarotReadingViewState();,
+  ConsumerState<_TarotReadingView> createState() => _TarotReadingViewState();
 }
 
 class _TarotReadingViewState extends ConsumerState<_TarotReadingView> {
@@ -701,7 +701,7 @@ class _TarotReadingViewState extends ConsumerState<_TarotReadingView> {
   @override
   void dispose() {
     _questionController.dispose();
-    super.dispose();,
+    super.dispose();
 }
 
   void _startReading() {
@@ -711,14 +711,14 @@ class _TarotReadingViewState extends ConsumerState<_TarotReadingView> {
                   message: '질문을 입력해주세요'),
                   type: ToastType.warning
       );
-      return;,
+      return;
 }
 
     // Navigate to the existing tarot page with spread type parameter
     context.push('/interactive/tarot', extra: {
       'spreadType': widget.spreadType.value)
       'question': _questionController.text),
-});,
+});
 }
 
   @override
@@ -835,7 +835,7 @@ class _TarotReadingViewState extends ConsumerState<_TarotReadingView> {
                 ),
             ),
       
-    );,
+    );
 }
 
   String _getSpreadDescription(TarotSpreadType type) {
@@ -849,8 +849,8 @@ class _TarotReadingViewState extends ConsumerState<_TarotReadingView> {
       case TarotSpreadType.relationship:
         return '관계의 역학과 잠재력을 탐구합니다';
       case TarotSpreadType.decision:
-        return '중요한 선택을 위한 명확한 가이드를 제공합니다';,
-}
+        return '중요한 선택을 위한 명확한 가이드를 제공합니다';
+    }
   }
 
   String _getQuestionHint(TarotSpreadType type) {
@@ -864,9 +864,9 @@ class _TarotReadingViewState extends ConsumerState<_TarotReadingView> {
       case TarotSpreadType.relationship:
         return '예: 우리 관계의 미래는 어떨까요?';
       case TarotSpreadType.decision:
-        return '예: 이직을 해야 할까요, 아니면 현재 직장에 남아야 할까요?';,
-}
-  },
+        return '예: 이직을 해야 할까요, 아니면 현재 직장에 남아야 할까요?';
+    }
+  }
 }
 
 // Glass Button with gradient support
@@ -895,8 +895,10 @@ class GlassButton extends StatelessWidget {
           decoration: BoxDecoration(
             gradient: gradient ?? LinearGradient(
               colors: [
-                theme.colorScheme.primary
-                theme.colorScheme.secondary),
+                theme.colorScheme.primary,
+                theme.colorScheme.secondary,
+              ],
+            ),
             borderRadius: BorderRadius.circular(12),
             boxShadow: [
               BoxShadow(
@@ -910,6 +912,6 @@ class GlassButton extends StatelessWidget {
               data: IconThemeData(color: Colors.white),
               child: child,
             ),
-        ));,
+        ));
 }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/enhanced_moving_result.dart.backup
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/enhanced_moving_result.dart.backup
@@ -231,7 +231,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '방위 분석')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -266,7 +266,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '지역 상세 분석')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -399,7 +399,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   title)
                   style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
                 const SizedBox(height: AppSpacing.spacing1))
                 Text(
@@ -430,7 +430,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '날짜 분석')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -453,7 +453,7 @@ class EnhancedMovingResult extends StatelessWidget {
                       child: Text(
                         '손없는날 - 모든 방향으로 이사하기 좋은 최고의 날입니다!')
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                   ])
                 ),
@@ -499,12 +499,12 @@ class EnhancedMovingResult extends StatelessWidget {
             child: Text(
               label)
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Colors.grey),))
+                color: Colors.grey))
               ))
           Text(
             value)
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w500),))
+              fontWeight: FontWeight.w500))
             ))
         ])
       )
@@ -533,7 +533,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '상세 운세 분석')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -606,7 +606,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '추천사항')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -655,7 +655,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '주의사항')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                     color: Colors.red.withValues(alpha: 0.9))
               ])
             ),

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/enhanced_moving_result.dart.bak2
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/enhanced_moving_result.dart.bak2
@@ -543,7 +543,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '상세 운세 분석')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -616,7 +616,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '추천사항')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                   ))
               ])
             ),
@@ -665,7 +665,7 @@ class EnhancedMovingResult extends StatelessWidget {
                 Text(
                   '주의사항')
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                     color: Colors.red.withValues(alpha: 0.9))
               ])
             ),

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/fortune_content_card.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/fortune_content_card.dart
@@ -25,13 +25,13 @@ class FortuneContentCard extends StatelessWidget {
               Text(
                 '상세 운세')
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               const SizedBox(height: AppSpacing.spacing3))
               Text(
                 fortune.content)
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  height: 1.6),))
+                  height: 1.6))
                 ))
               const SizedBox(height: AppSpacing.spacing6))
             ])
@@ -42,7 +42,7 @@ class FortuneContentCard extends StatelessWidget {
               Text(
                 '분야별 운세',
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               const SizedBox(height: AppSpacing.spacing4))
               ..._buildScoreBreakdown(context))
@@ -55,7 +55,7 @@ class FortuneContentCard extends StatelessWidget {
               Text(
                 '행운의 아이템',
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               const SizedBox(height: AppSpacing.spacing4))
               _buildLuckyItems(context))
@@ -68,7 +68,7 @@ class FortuneContentCard extends StatelessWidget {
               Text(
                 '추천 사항',
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               const SizedBox(height: AppSpacing.spacing3))
               ...fortune.recommendations!.map(
@@ -99,7 +99,7 @@ class FortuneContentCard extends StatelessWidget {
               Text(
                 '주의 사항',
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               const SizedBox(height: AppSpacing.spacing3))
               ...fortune.warnings!.map(
@@ -170,12 +170,12 @@ class FortuneContentCard extends StatelessWidget {
                       Text(
                         category.$2)
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w600),))
+                          fontWeight: FontWeight.w600))
                         ))
                       Text(
                         '$score점')
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                           color: category.$4)
                         ))
                     ])
@@ -277,12 +277,12 @@ class FortuneContentCard extends StatelessWidget {
               Text(
                 label)
                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: context.fortuneTheme.subtitleText),))
+                  color: context.fortuneTheme.subtitleText))
                 ))
               Text(
                 value)
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                   color: color)
                 ))
             ])

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_color_detail_card.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_color_detail_card.dart
@@ -44,13 +44,13 @@ class LuckyColorDetailCard extends StatelessWidget {
           Text(
             '오늘의 행운 색상')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
           const SizedBox(height: AppSpacing.spacing2))
           Text(
             '색상의 에너지가 당신의 하루를 더욱 특별하게 만들어줄 거예요')
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Colors.grey[600]),))
+                  color: Colors.grey[600]))
                 ),
         ])
       )
@@ -96,7 +96,7 @@ class LuckyColorDetailCard extends StatelessWidget {
               Text(
                 mainLuckyColorName)
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                     ))
               const SizedBox(height: AppSpacing.spacing2))
               _buildColorPalette(context))
@@ -200,7 +200,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                     child: Text(
                       category.title)
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                           ))
                       maxLines: 1)
                       overflow: TextOverflow.ellipsis)
@@ -229,7 +229,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                       child: Text(
                         items.first.value)
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold),))
+                              fontWeight: FontWeight.bold))
                             ))
                   ])
                 ),
@@ -237,7 +237,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                 Text(
                   items.first.reason)
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600]),))
+                        color: Colors.grey[600]))
                       ),
                   maxLines: 2)
                   overflow: TextOverflow.ellipsis)
@@ -246,7 +246,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                 Text(
                   category.description,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600]),))
+                        color: Colors.grey[600]))
                       ),
                   maxLines: 3)
                   overflow: TextOverflow.ellipsis)
@@ -258,7 +258,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                   Text(
                     '자세히 보기')
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: mainLuckyColor),))
+                          color: mainLuckyColor))
                         ))
                   const SizedBox(width: AppSpacing.spacing1))
                   Icon(
@@ -380,7 +380,7 @@ class LuckyColorDetailCard extends StatelessWidget {
         Text(
           '추천 활용법')
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ))
         const SizedBox(height: AppSpacing.spacing4))
         ...category.examples.map(
@@ -449,7 +449,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                         Text(
                           item.value)
                           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold),))
+                                fontWeight: FontWeight.bold))
                               ))
                         if (item.priority != null)
                           Container(
@@ -465,7 +465,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                             child: Text(
                               _getPriorityText(item.priority!))
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                    color: Colors.white),))
+                                    color: Colors.white))
                                     fontSize: Theme.of(context).textTheme.bodySmall!.fontSize)
                                   ))
                             ))
@@ -492,7 +492,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                     Text(
                       item.timeRange!)
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Colors.grey[600]),))
+                            color: Colors.grey[600]))
                           ),
                   ])
                 ),
@@ -517,7 +517,7 @@ class LuckyColorDetailCard extends StatelessWidget {
                         child: Text(
                           item.situation!)
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: Colors.grey[700]),))
+                                color: Colors.grey[700]))
                               ),
                     ])
                   ),

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_food_detail_card.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_food_detail_card.dart
@@ -40,13 +40,13 @@ class LuckyFoodDetailCard extends StatelessWidget {
           Text(
             '오늘의 행운 음식')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
           const SizedBox(height: AppSpacing.spacing2))
           Text(
             '맛있는 음식으로 행운의 에너지를 충전하세요')
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Colors.grey[600]),))
+                  color: Colors.grey[600]))
                 ),
         ])
       )
@@ -90,7 +90,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
               Text(
                 mainLuckyFood)
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                     ))
               const SizedBox(height: AppSpacing.spacing2))
               Container(
@@ -102,7 +102,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                 child: Text(
                   '오늘의 추천 메인 메뉴')
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.orange[700]),))
+                        color: Colors.orange[700]))
                         fontWeight: FontWeight.w500,
                       ))
             ])
@@ -242,7 +242,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                           Text(
                             category.title)
                             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                                  fontWeight: FontWeight.bold),))
+                                  fontWeight: FontWeight.bold))
                                 ))
                             maxLines: 1)
                             overflow: TextOverflow.ellipsis)
@@ -251,7 +251,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                             Text(
                               '지금 추천!')
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                    color: Colors.orange),))
+                                    color: Colors.orange))
                                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                     fontWeight: FontWeight.bold)
                                   ))
@@ -273,7 +273,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                         child: Text(
                           items.first.value)
                           style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                                fontWeight: FontWeight.w600),))
+                                fontWeight: FontWeight.w600))
                               ))
                           maxLines: 1)
                           overflow: TextOverflow.ellipsis)
@@ -285,7 +285,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                   Text(
                     items.first.reason)
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Colors.grey[600]),))
+                          color: Colors.grey[600]))
                           fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
                         ))
                     maxLines: 2)
@@ -295,7 +295,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                   Text(
                     category.description,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Colors.grey[600]),))
+                          color: Colors.grey[600]))
                         ),
                     maxLines: 3)
                     overflow: TextOverflow.ellipsis)
@@ -307,7 +307,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                     Text(
                       '더보기')
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Colors.orange),))
+                            color: Colors.orange))
                             fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                           ))
                     ))
@@ -434,7 +434,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
         Text(
           '추천 메뉴 카테고리')
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ))
         const SizedBox(height: AppSpacing.spacing4))
         ...category.examples.map(
@@ -508,7 +508,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                                 child: Text(
                                   '#$index')
                                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                        fontWeight: FontWeight.bold),))
+                                        fontWeight: FontWeight.bold))
                                         fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                       ))
                                 ))
@@ -517,7 +517,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                               child: Text(
                                 item.value)
                                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                      fontWeight: FontWeight.bold),))
+                                      fontWeight: FontWeight.bold))
                                     ))
                           ])
                         ),
@@ -535,7 +535,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                             child: Text(
                               _getPriorityText(item.priority!))
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                    color: Colors.white),))
+                                    color: Colors.white))
                                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                   ))
                             ))
@@ -572,7 +572,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                       Text(
                         item.timeRange!)
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Colors.blue[700]),))
+                              color: Colors.blue[700]))
                               fontWeight: FontWeight.w500,
                             ))
                     ])
@@ -599,7 +599,7 @@ class LuckyFoodDetailCard extends StatelessWidget {
                         child: Text(
                           item.situation!)
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: Colors.amber[900]),))
+                                color: Colors.amber[900]))
                               ),
                     ])
                   ),

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_item_detail_card.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_item_detail_card.dart
@@ -49,13 +49,13 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
           Text(
             '오늘의 행운 아이템')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
           const SizedBox(height: AppSpacing.spacing2))
           Text(
             '작은 아이템이 큰 행운을 가져다줄 거예요')
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Colors.grey[600]),))
+                  color: Colors.grey[600]))
                 ),
         ])
       )
@@ -102,7 +102,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
               Text(
                 widget.mainLuckyItem)
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                     ))
               const SizedBox(height: AppSpacing.spacing2))
               Container(
@@ -128,7 +128,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                     Text(
                       '오늘의 핵심 아이템')
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Colors.purple[700]),))
+                            color: Colors.purple[700]))
                             fontWeight: FontWeight.w600,
                           ))
                   ])
@@ -281,7 +281,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                     child: Text(
                       category.title)
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                           ))
                       maxLines: 1)
                       overflow: TextOverflow.ellipsis)
@@ -303,7 +303,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                       child: Text(
                         items.first.value)
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                              color: Colors.purple[700]),))
+                              color: Colors.purple[700]))
                               fontWeight: FontWeight.w600,
                             ))
                         maxLines: 1)
@@ -316,7 +316,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                 Text(
                   items.first.reason)
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600]),))
+                        color: Colors.grey[600]))
                         fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
                       ))
                   maxLines: 2)
@@ -327,7 +327,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                   child: Text(
                     category.description,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Colors.grey[600]),))
+                          color: Colors.grey[600]))
                         ),
                     maxLines: 4)
                     overflow: TextOverflow.ellipsis)
@@ -341,7 +341,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                     Text(
                       '${items.length}개 아이템',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Colors.grey),))
+                            color: Colors.grey))
                             fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                           ))
                     )
@@ -352,7 +352,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                       Text(
                         '자세히')
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Colors.purple),))
+                              color: Colors.purple))
                               fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                             ))
                       ))
@@ -469,13 +469,13 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                 Text(
                   category.title)
                   style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                       ))
                 const SizedBox(height: AppSpacing.spacing1))
                 Text(
                   category.description)
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Colors.grey[600]),))
+                        color: Colors.grey[600]))
                       ),
               ])
             ),
@@ -495,7 +495,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
         Text(
           '추천 아이템 예시')
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ))
         const SizedBox(height: AppSpacing.spacing4))
         ...category.examples.map(
@@ -536,7 +536,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
         Text(
           '오늘의 추천 아이템 (${items.length}개)')
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ),
         const SizedBox(height: AppSpacing.spacing4))
         ...items.asMap().entries.map(
@@ -603,7 +603,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                                   child: Text(
                                     '#$index')
                                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                          color: Colors.purple),))
+                                          color: Colors.purple))
                                           fontWeight: FontWeight.bold)
                                           fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                         ))
@@ -613,7 +613,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                                 child: Text(
                                   item.value)
                                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                        fontWeight: FontWeight.bold),))
+                                        fontWeight: FontWeight.bold))
                                       ))
                             ])
                           ),
@@ -633,7 +633,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                                   child: Text(
                                     _getPriorityText(item.priority!))
                                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                          color: Colors.white),))
+                                          color: Colors.white))
                                           fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                         ))
                                   ))
@@ -649,7 +649,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                                 Text(
                                   item.timeRange!)
                                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                        color: Colors.grey[600]),))
+                                        color: Colors.grey[600]))
                                         fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
                                       ))
                                 ))
@@ -670,7 +670,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                 Text(
                   item.reason)
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Colors.grey[700]),))
+                        color: Colors.grey[700]))
                       ),
                   maxLines: 2)
                   overflow: TextOverflow.ellipsis)
@@ -721,7 +721,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
               Text(
                 item.value)
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                     ))
                 textAlign: TextAlign.center)
               ))
@@ -739,7 +739,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                   child: Text(
                     _getPriorityText(item.priority!))
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Colors.white),))
+                          color: Colors.white))
                           fontWeight: FontWeight.bold)
                         ))
               ])
@@ -772,7 +772,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                       Text(
                         item.timeRange!)
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              color: Colors.blue[700]),))
+                              color: Colors.blue[700]))
                               fontWeight: FontWeight.w500,
                             ))
                     ])
@@ -799,7 +799,7 @@ class _LuckyItemDetailCardState extends State<LuckyItemDetailCard> {
                         child: Text(
                           item.situation!)
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: Colors.amber[900]),))
+                                color: Colors.amber[900]))
                               ),
                     ])
                   ),

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_number_detail_card.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/lucky_number_detail_card.dart
@@ -40,13 +40,13 @@ class LuckyNumberDetailCard extends StatelessWidget {
           Text(
             '오늘의 행운 숫자')
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
           const SizedBox(height: AppSpacing.spacing2))
           Text(
             '일상 속에서 만나는 숫자들이 오늘 당신에게 행운을 가져다줄 거예요')
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Colors.grey[600]),))
+                  color: Colors.grey[600]))
                 ),
         ])
       )
@@ -85,7 +85,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                   child: Text(
                     mainLuckyNumber.toString())
                     style: Theme.of(context).textTheme.displayMedium?.copyWith(
-                          color: Colors.white),))
+                          color: Colors.white))
                           fontWeight: FontWeight.bold)
                         ))
               ))
@@ -160,7 +160,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                     child: Text(
                       category.title)
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                           ))
                       maxLines: 1)
                       overflow: TextOverflow.ellipsis)
@@ -181,7 +181,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                 Text(
                   items.first.reason)
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600]),))
+                        color: Colors.grey[600]))
                       ),
                   maxLines: 2)
                   overflow: TextOverflow.ellipsis)
@@ -190,7 +190,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                 Text(
                   category.description,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600]),))
+                        color: Colors.grey[600]))
                       ),
                   maxLines: 3)
                   overflow: TextOverflow.ellipsis)
@@ -327,7 +327,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
         Text(
           '추천 활용법')
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ))
         const SizedBox(height: AppSpacing.spacing4))
         ...category.examples.map(
@@ -389,7 +389,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                         _getPriorityText(item.priority!))
                         style:
                             Theme.of(context).textTheme.bodySmall?.copyWith(
-                                  color: Colors.white),))
+                                  color: Colors.white))
                                   fontWeight: FontWeight.bold)
                                 ))
                 ])
@@ -411,7 +411,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                     Text(
                       item.timeRange!)
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Colors.grey[600]),))
+                            color: Colors.grey[600]))
                           ),
                   ])
                 ),
@@ -430,7 +430,7 @@ class LuckyNumberDetailCard extends StatelessWidget {
                       child: Text(
                         item.situation!)
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Colors.grey[600]),))
+                              color: Colors.grey[600]))
                             ),
                   ])
                 ),

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/personality_analysis_options.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/personality_analysis_options.dart
@@ -223,7 +223,7 @@ class _AnalysisOptionCardState extends State<_AnalysisOptionCard>
                         Text(
                           widget.title)
                           style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                             color: widget.value ? widget.color : null)
                           ))
                         const SizedBox(height: AppSpacing.spacing0 * 0.5))

--- a/fortune_flutter/lib/features/fortune/presentation/widgets/personality_traits_chips.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/widgets/personality_traits_chips.dart
@@ -105,7 +105,7 @@ class PersonalityTraitsChips extends StatelessWidget {
                     Text(
                       group['title'] as String,
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                         color: color,
                       ))
                   ])

--- a/fortune_flutter/lib/features/interactive/presentation/widgets/enhanced_tarot_fan_widget.dart
+++ b/fortune_flutter/lib/features/interactive/presentation/widgets/enhanced_tarot_fan_widget.dart
@@ -164,7 +164,7 @@ class _EnhancedTarotFanWidgetState extends State<EnhancedTarotFanWidget>
                 Text(
                   widget.fortuneType)
                   style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-                    color: Colors.white),))
+                    color: Colors.white))
                     fontWeight: FontWeight.bold)
                   ))
                 const SizedBox(height: 8))

--- a/fortune_flutter/lib/features/payment/presentation/pages/in_app_purchase_page.dart
+++ b/fortune_flutter/lib/features/payment/presentation/pages/in_app_purchase_page.dart
@@ -425,7 +425,7 @@ class _InAppPurchasePageState extends ConsumerState<InAppPurchasePage> {
                             child: Text(
                               '인기')
                               style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                color: Colors.white),))
+                                color: Colors.white))
                                 fontWeight: FontWeight.bold)
                                 fontSize: 10)
                               ))

--- a/fortune_flutter/lib/presentation/screens/fortune/base_fortune_screen.dart
+++ b/fortune_flutter/lib/presentation/screens/fortune/base_fortune_screen.dart
@@ -303,7 +303,7 @@ https://fortune.app
           Text(
             widget.title)
             style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-              color: Colors.white),))
+              color: Colors.white))
               fontWeight: FontWeight.bold)
             ))
           const SizedBox(height: AppSpacing.spacing2))
@@ -372,7 +372,7 @@ https://fortune.app
               Text(
                 '다른 운세도 확인해보세요')
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ))
               const SizedBox(height: AppSpacing.spacing4))
               Wrap(

--- a/fortune_flutter/lib/presentation/screens/fortune/daily_fortune_screen.dart
+++ b/fortune_flutter/lib/presentation/screens/fortune/daily_fortune_screen.dart
@@ -99,7 +99,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                   Text(
                     '${fortune.score}')
                     style: Theme.of(context).textTheme.displayMedium?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                       color: _getScoreColor(fortune.score),
                   ))
                   Text(
@@ -162,7 +162,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
               Text(
                 '오늘의 메시지')
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                   color: Colors.purple.withValues(alpha: 0.9))
               ))
             ])
@@ -171,7 +171,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
           Text(
             fortune.summary)
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              height: 1.6),))
+              height: 1.6))
               color: Colors.purple.withValues(alpha: 0.92))
           ))
           const SizedBox(height: AppSpacing.spacing4))
@@ -202,7 +202,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
         Text(
           '운세 영역별 점수')
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            fontWeight: FontWeight.bold),))
+            fontWeight: FontWeight.bold))
           ))
         const SizedBox(height: AppSpacing.spacing4))
         _buildElementCard(
@@ -254,7 +254,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
           Text(
             '오늘의 행운 아이템')
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold),))
+              fontWeight: FontWeight.bold))
             ))
           const SizedBox(height: AppSpacing.spacing4))
           Row(
@@ -286,7 +286,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                   value: Text(
                     '${fortune.luckyNumber}')
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold),))
+                      fontWeight: FontWeight.bold))
                       color: Theme.of(context).colorScheme.primary,
                     ))
                   ))
@@ -305,7 +305,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                   value: Text(
                     fortune.bestTime)
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w600),))
+                      fontWeight: FontWeight.w600))
                     ))
                 ))
               ))
@@ -318,7 +318,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                   value: Text(
                     fortune.compatibility)
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w600),))
+                      fontWeight: FontWeight.w600))
                     ))
                 ))
               ))
@@ -368,7 +368,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                           Text(
                             '오늘의 조언')
                             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold),))
+                              fontWeight: FontWeight.bold))
                             ))
                           Text(
                             fortune.advice)
@@ -411,7 +411,7 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                           Text(
                             '주의사항')
                             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold),))
+                              fontWeight: FontWeight.bold))
                             ))
                           Text(
                             fortune.caution)
@@ -498,12 +498,12 @@ class _DailyFortuneScreenState extends BaseFortuneScreenState<DailyFortuneScreen
                     Text(
                       title)
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600),))
+                        fontWeight: FontWeight.w600))
                       ))
                     Text(
                       '$score%')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                         color: color)
                       ))
                   ])

--- a/fortune_flutter/lib/presentation/splash/splash_screen.dart
+++ b/fortune_flutter/lib/presentation/splash/splash_screen.dart
@@ -59,7 +59,7 @@ class _SplashScreenState extends State<SplashScreen> {
             Text(
               'Fortune.')
               style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-                color: Colors.white),))
+                color: Colors.white))
                 fontWeight: FontWeight.w300)
                 letterSpacing: 2)
                 fontFamily: 'NotoSansKR')

--- a/fortune_flutter/lib/presentation/widgets/ad_widgets.dart
+++ b/fortune_flutter/lib/presentation/widgets/ad_widgets.dart
@@ -40,7 +40,7 @@ class AdDialog extends ConsumerWidget {
               '광고 시청하기'),
         style: Theme.of(context).textTheme.headlineSmall?.copyWith(,
       fontWeight: FontWeight.bold,
-                          ),))
+                          ))
               ))
             SizedBox(height: AppSpacing.spacing2))
             Text(
@@ -154,13 +154,13 @@ class NativeAdWidget extends StatelessWidget {
                           'Sponsored Content',
                           style: Theme.of(context).textTheme.titleSmall?.copyWith(,
       fontWeight: FontWeight.bold,
-                          ),))
+                          ))
                       ))
                     Text(
                       'Learn more'),
         style: Theme.of(context).textTheme.bodySmall?.copyWith(,
       color: AppColors.primary,
-                          ),))
+                          ))
                       ))
                   ])
                 ))))

--- a/fortune_flutter/lib/presentation/widgets/daily_fortune_card.dart
+++ b/fortune_flutter/lib/presentation/widgets/daily_fortune_card.dart
@@ -72,7 +72,7 @@ class DailyFortuneCard extends StatelessWidget {
                         Text(
                           '${timeGreeting['greeting']} 운세',
                           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                           ))
                         Text(
                           '${now.month}월 ${now.day}일 ${_getWeekday(now.weekday)} • ${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}',
@@ -149,7 +149,7 @@ class DailyFortuneCard extends StatelessWidget {
               child: Text(
                 '${fortune!.score}점')
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                   color: Theme.of(context).textTheme.headlineSmall?.color,
                 ))
               ))
@@ -164,7 +164,7 @@ class DailyFortuneCard extends StatelessWidget {
               child: Text(
                 fortune!.mood)
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w500),))
+                  fontWeight: FontWeight.w500))
                   color: Theme.of(context).textTheme.bodyMedium?.color)
                 ))
               ))
@@ -177,7 +177,7 @@ class DailyFortuneCard extends StatelessWidget {
                 Text(
                   '에너지 ${fortune!.energy}%')
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.fortuneTheme.subtitleText),))
+                    color: context.fortuneTheme.subtitleText))
                   ),
               ])
             ),
@@ -350,7 +350,7 @@ class DailyFortuneCard extends StatelessWidget {
                             Text(
                               '행운의 색')
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                fontWeight: FontWeight.w500),))
+                                fontWeight: FontWeight.w500))
                                 color: Theme.of(context).textTheme.bodyMedium?.color ?? Theme.of(context).colorScheme.onSurface)
                               ))
                             ))
@@ -391,7 +391,7 @@ class DailyFortuneCard extends StatelessWidget {
                             Text(
                               '행운의 숫자: ${fortune!.luckyNumber}',
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                fontWeight: FontWeight.w500),))
+                                fontWeight: FontWeight.w500))
                                 color: Theme.of(context).textTheme.bodyMedium?.color ?? Theme.of(context).colorScheme.onSurface)
                               ))
                             ))
@@ -418,7 +418,7 @@ class DailyFortuneCard extends StatelessWidget {
             Text(
               fortune!.bestTime)
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: context.fortuneTheme.subtitleText),))
+                color: context.fortuneTheme.subtitleText))
               ))
             SizedBox(width: AppSpacing.spacing4))
             Icon(Icons.people_outline, size: 14, color: context.fortuneTheme.subtitleText))
@@ -426,7 +426,7 @@ class DailyFortuneCard extends StatelessWidget {
             Text(
               fortune!.compatibility)
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: context.fortuneTheme.subtitleText),))
+                color: context.fortuneTheme.subtitleText))
               ))
           ])
         ),
@@ -467,7 +467,7 @@ class DailyFortuneCard extends StatelessWidget {
                 Text(
                   '$value%')
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontWeight: FontWeight.bold),))
+                    fontWeight: FontWeight.bold))
                     color: Theme.of(context).textTheme.headlineSmall?.color)
                   ))
                 ))
@@ -505,7 +505,7 @@ class DailyFortuneCard extends StatelessWidget {
           Text(
             '오늘의 운세를 확인해보세요')
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: context.fortuneTheme.subtitleText),))
+              color: context.fortuneTheme.subtitleText))
             ))
         ])
       )

--- a/fortune_flutter/lib/presentation/widgets/daily_fortune_summary_card.dart
+++ b/fortune_flutter/lib/presentation/widgets/daily_fortune_summary_card.dart
@@ -590,7 +590,7 @@ class DailyFortuneSummaryCard extends StatelessWidget {
         ),
         style: Theme.of(context).textTheme.labelSmall?.copyWith(,
       color: context.fortuneTheme.subtitleText,
-                          ),))
+                          ))
           if (value != null) ...[
             SizedBox(height: AppSpacing.xxxSmall),
             Text(
@@ -598,7 +598,7 @@ class DailyFortuneSummaryCard extends StatelessWidget {
               ),
               style: Theme.of(context).textTheme.labelSmall?.copyWith(,
       fontWeight: FontWeight.bold,
-                          ),))
+                          ))
           ]
         ]
       )

--- a/fortune_flutter/lib/presentation/widgets/fortune_history_summary_widget.dart
+++ b/fortune_flutter/lib/presentation/widgets/fortune_history_summary_widget.dart
@@ -381,7 +381,7 @@ class _FortuneHistorySummaryWidgetState extends ConsumerState<FortuneHistorySumm
             '• $title'),
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(,
       fontWeight: FontWeight.w500,
-                          ),))
+                          ))
         Text(
           '($score점)',
           style: TextStyle(,

--- a/fortune_flutter/lib/presentation/widgets/personalized_fortune_card.dart
+++ b/fortune_flutter/lib/presentation/widgets/personalized_fortune_card.dart
@@ -123,13 +123,13 @@ class PersonalizedFortuneCard extends StatelessWidget {
                     Text(
                       '환영합니다! 🎉')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                       ))
                     SizedBox(height: AppSpacing.spacing1))
                     Text(
                       '다양한 운세를 확인하고 나만의 운세를 찾아보세요')
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: context.fortuneTheme.subtitleText),))
+                        color: context.fortuneTheme.subtitleText))
                       ))
                   ])
                 ),
@@ -235,7 +235,7 @@ class PersonalizedFortuneCard extends StatelessWidget {
                                 child: Text(
                                   '나의 관심 운세')
                                   style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                    color: AppColors.textPrimaryDark),))
+                                    color: AppColors.textPrimaryDark))
                                     fontWeight: FontWeight.bold)
                                     fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                   ))
@@ -252,7 +252,7 @@ class PersonalizedFortuneCard extends StatelessWidget {
                                   child: Text(
                                     '자주 봄')
                                     style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                      color: AppColors.textPrimaryDark),))
+                                      color: AppColors.textPrimaryDark))
                                       fontWeight: FontWeight.bold)
                                       fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize)
                                     ))
@@ -264,7 +264,7 @@ class PersonalizedFortuneCard extends StatelessWidget {
                           Text(
                             fortuneTypeInfo['name'])
                             style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                              fontWeight: FontWeight.bold),))
+                              fontWeight: FontWeight.bold))
                               color: AppColors.textPrimaryDark,
                             ))
                           Text(
@@ -314,7 +314,7 @@ class PersonalizedFortuneCard extends StatelessWidget {
                                 Text(
                                   '최근 운세 결과')
                                   style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                                    color: context.fortuneTheme.subtitleText),))
+                                    color: context.fortuneTheme.subtitleText))
                                   ))
                               ])
                             ),
@@ -338,7 +338,7 @@ class PersonalizedFortuneCard extends StatelessWidget {
                                     child: Text(
                                       '${recentFortune!['score']}점')
                                       style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                                        color: fortuneTypeInfo['color']),))
+                                        color: fortuneTypeInfo['color']))
                                         fontWeight: FontWeight.bold,
                                       ))
                                 ])

--- a/fortune_flutter/lib/screens/home/home_screen_updated.dart
+++ b/fortune_flutter/lib/screens/home/home_screen_updated.dart
@@ -501,7 +501,7 @@ class _HomeScreenUpdatedState extends ConsumerState<HomeScreenUpdated> {
               Text(
                 service['title'] as String,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                 ),
               SizedBox(height: AppSpacing.spacing1))
               Text(
@@ -551,7 +551,7 @@ class _HomeScreenUpdatedState extends ConsumerState<HomeScreenUpdated> {
                         child: Text(
                           fortune['title'] as String,
                           style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                            fontWeight: FontWeight.bold),))
+                            fontWeight: FontWeight.bold))
                           ),
                           overflow: TextOverflow.ellipsis)
                         ))
@@ -641,7 +641,7 @@ class _HomeScreenUpdatedState extends ConsumerState<HomeScreenUpdated> {
                             Text(
                               fortune['title'] as String,
                               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                fontWeight: FontWeight.bold),))
+                                fontWeight: FontWeight.bold))
                               ),
                             SizedBox(width: AppSpacing.spacing2))
                             Container(
@@ -658,7 +658,7 @@ class _HomeScreenUpdatedState extends ConsumerState<HomeScreenUpdated> {
                               child: Text(
                                 fortune['badge'] as String,
                                 style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                  color: fortune['color'] as Color),))
+                                  color: fortune['color'] as Color))
                                   fontWeight: FontWeight.bold,
                                 ))
                           ])

--- a/fortune_flutter/lib/screens/onboarding/steps/birth_info_step.dart
+++ b/fortune_flutter/lib/screens/onboarding/steps/birth_info_step.dart
@@ -106,7 +106,7 @@ class _BirthInfoStepState extends State<BirthInfoStep> {
                   '정확한 운세를 위해 필요해요',
                           style: Theme.of(context).textTheme.bodyLarge?.copyWith(,
       color: context.fortuneTheme.subtitleText,
-                          ),))
+                          ))
                   textAlign: TextAlign.center)).animate(del,
       ay: 300.ms).fadeIn(duratio,
       n: 600.ms),

--- a/fortune_flutter/lib/screens/onboarding/steps/gender_step.dart
+++ b/fortune_flutter/lib/screens/onboarding/steps/gender_step.dart
@@ -79,7 +79,7 @@ class _GenderStepState extends State<GenderStep> {
                   '음양의 조화를 살펴볼게요',
                           style: Theme.of(context).textTheme.bodyLarge?.copyWith(,
       color: context.fortuneTheme.subtitleText,
-                          ),))
+                          ))
                   textAlign: TextAlign.center)).animate(del,
       ay: 300.ms).fadeIn(duratio,
       n: 600.ms),

--- a/fortune_flutter/lib/screens/onboarding/steps/location_step.dart
+++ b/fortune_flutter/lib/screens/onboarding/steps/location_step.dart
@@ -89,7 +89,7 @@ class _LocationStepState extends State<LocationStep> {
                   '운세의 정확도를 높이기 위해\n지역 정보가 필요해요'),
         style: Theme.of(context).textTheme.bodyLarge?.copyWith(,
       color: context.fortuneTheme.subtitleText,
-                          ),))
+                          ))
                   textAlign: TextAlign.center)).animate(del,
       ay: 300.ms).fadeIn(duratio,
       n: 600.ms),
@@ -146,7 +146,7 @@ class _LocationStepState extends State<LocationStep> {
                       '완료'),
         style: Theme.of(context).textTheme.titleMedium?.copyWith(,
       fontWeight: FontWeight.w600,
-                          ),))))).animate(delay: 700.ms).fadeIn(duratio,
+                          ))))).animate(delay: 700.ms).fadeIn(duratio,
       n: 600.ms),
               ])))
         ]

--- a/fortune_flutter/lib/screens/onboarding/steps/mbti_step.dart
+++ b/fortune_flutter/lib/screens/onboarding/steps/mbti_step.dart
@@ -160,7 +160,7 @@ class _MbtiStepState extends State<MbtiStep> {
                     child: Text(
                       'MBTI 선택 시작')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600),))
+                        fontWeight: FontWeight.w600))
                       ))
                   )
                 else
@@ -194,7 +194,7 @@ class _MbtiStepState extends State<MbtiStep> {
                   Text(
                     '${_currentDimension}/4 단계',
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: context.fortuneTheme.subtitleText),))
+                      color: context.fortuneTheme.subtitleText))
                     ))
                 
                 if (isComplete)

--- a/fortune_flutter/lib/screens/onboarding/steps/social_login_step.dart
+++ b/fortune_flutter/lib/screens/onboarding/steps/social_login_step.dart
@@ -136,7 +136,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
             Text(
               label)
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.w600),))
+                fontWeight: FontWeight.w600))
                 color: textColor ?? context.fortuneTheme.primaryText)
               ))
           ])
@@ -154,7 +154,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
         Text(
           '거의 다 왔습니다!')
           style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
               ))
           textAlign: TextAlign.center)
         ))
@@ -162,7 +162,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
         Text(
           '계정을 연결하면 모든 기기에서\n운세를 확인할 수 있습니다')
           style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: context.fortuneTheme.subtitleText),))
+                color: context.fortuneTheme.subtitleText))
               ))
           textAlign: TextAlign.center)
         ))
@@ -184,7 +184,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
                   child: Text(
                     _errorMessage!)
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: context.fortuneTheme.errorColor),))
+                      color: context.fortuneTheme.errorColor))
                     ))
               ])
             ),
@@ -238,7 +238,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
                     child: Text(
                       'K')
                       style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                         color: const Color(0xFFFEE500), // Kakao brand color
                       ))
                     ))
@@ -263,7 +263,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
               child: Text(
                 'N')
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  fontWeight: FontWeight.bold),))
+                  fontWeight: FontWeight.bold))
                   color: const Color(0xFF03C75A), // Naver brand color
                 ))
               ))
@@ -282,7 +282,7 @@ class _SocialLoginStepState extends ConsumerState<SocialLoginStep> {
             child: Text(
               '나중에 하기')
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: context.fortuneTheme.subtitleText),))
+                color: context.fortuneTheme.subtitleText))
               ))
 
         if (_isLoading) ...[

--- a/fortune_flutter/lib/screens/onboarding/widgets/bottom_sheet_date_picker.dart
+++ b/fortune_flutter/lib/screens/onboarding/widgets/bottom_sheet_date_picker.dart
@@ -82,14 +82,14 @@ class _BottomSheetDatePickerState extends State<BottomSheetDatePicker> {
                   child: Text(
                     '취소')
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: context.fortuneTheme.subtitleText),))
+                      color: context.fortuneTheme.subtitleText))
                     ))
                 Column(
                   children: [
                     Text(
                       '생년월일')
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600),))
+                        fontWeight: FontWeight.w600))
                       ))
                     SizedBox(height: context.fortuneTheme.formStyles.inputPadding.vertical * 0.25))
                     Text(
@@ -106,7 +106,7 @@ class _BottomSheetDatePickerState extends State<BottomSheetDatePicker> {
                   child: Text(
                     '확인')
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w600),))
+                      fontWeight: FontWeight.w600))
                     ))
               ])
             ),

--- a/fortune_flutter/lib/screens/onboarding/widgets/bottom_sheet_mbti_picker.dart
+++ b/fortune_flutter/lib/screens/onboarding/widgets/bottom_sheet_mbti_picker.dart
@@ -97,7 +97,7 @@ class BottomSheetMbtiPicker extends StatelessWidget {
             child: Text(
               dimension)
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.w600),))
+                fontWeight: FontWeight.w600))
               ))
           
           // Options
@@ -142,7 +142,7 @@ class BottomSheetMbtiPicker extends StatelessWidget {
             Text(
               option)
               style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                fontWeight: FontWeight.bold),))
+                fontWeight: FontWeight.bold))
                 color: isSelected ? Theme.of(context).primaryColor : context.fortuneTheme.primaryText)
               ))
             ))
@@ -150,7 +150,7 @@ class BottomSheetMbtiPicker extends StatelessWidget {
             Text(
               _getDescription(option))
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: context.fortuneTheme.subtitleText),))
+                color: context.fortuneTheme.subtitleText))
               ))
           ])
         ),

--- a/fortune_flutter/lib/screens/onboarding/widgets/onboarding_step_two.dart
+++ b/fortune_flutter/lib/screens/onboarding/widgets/onboarding_step_two.dart
@@ -27,7 +27,7 @@ class OnboardingStepTwo extends StatelessWidget {
                           'MBTI 선택 (선택사항)',
           style: Theme.of(context).textTheme.titleMedium?.copyWith(,
       fontWeight: FontWeight.bold,
-                          ),))
+                          ))
         SizedBox(height: context.fortuneTheme.formStyles.inputPadding.horizontal * 1.25),
         
         DropdownButtonFormField<String>(
@@ -50,7 +50,7 @@ class OnboardingStepTwo extends StatelessWidget {
           '성격 기반 운세 분석에 활용됩니다.',
                           style: Theme.of(context).textTheme.bodySmall?.copyWith(,
       color: context.fortuneTheme.subtitleText,
-                          ),))
+                          ))
         
         const Spacer(),
         

--- a/fortune_flutter/lib/screens/settings/screenshot_settings_page.dart
+++ b/fortune_flutter/lib/screens/settings/screenshot_settings_page.dart
@@ -78,7 +78,7 @@ class ScreenshotSettingsPage extends ConsumerWidget {
                       Text(
                         '스크린샷 감지 기능')
                         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold),))
+                          fontWeight: FontWeight.bold))
                         ))
                     ])
                   ),
@@ -86,7 +86,7 @@ class ScreenshotSettingsPage extends ConsumerWidget {
                   Text(
                     '스크린샷을 찍으면 자동으로 감지하여 더 예쁜 이미지로 공유할 수 있도록 도와드립니다.')
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      height: 1.5),))
+                      height: 1.5))
                     ))
                 ])
               ),
@@ -121,7 +121,7 @@ class ScreenshotSettingsPage extends ConsumerWidget {
                     Text(
                       '이런 기능이 제공됩니다')
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.bold),))
+                        fontWeight: FontWeight.bold))
                       ))
                     SizedBox(height: AppSpacing.spacing3))
                     _buildBenefitItem(
@@ -221,7 +221,7 @@ class ScreenshotSettingsPage extends ConsumerWidget {
               Text(
                 title)
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600),))
+                  fontWeight: FontWeight.w600))
                 ))
               Text(
                 description)


### PR DESCRIPTION
## Summary
- fix misplaced semicolons and commas in Talisman generation step
- fix switch-case commas and gradient brackets in Tarot enhanced page
- remove redundant parentheses in various widgets and backup files

## Testing
- `python test_supabase_connection.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688c530d0278832fad0a7295be01ebf2