### PR TITLE
Fix syntax in fortune presentation pages

### DIFF
--- a/fortune_flutter/lib/features/fortune/presentation/pages/lucky_running_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/lucky_running_fortune_page.dart
@@ -170,7 +170,7 @@ class _RunningInputFormState extends State<_RunningInputForm> {
               gradient: isSelected
                   ? const LinearGradient(
                       colors: [Color(0xFF3B82F6), Color(0xFF1E40AF)],
-                    ,
+                    ),
                   : null,
               border: Border.all(
                 color: isSelected
@@ -231,7 +231,7 @@ class _RunningInputFormState extends State<_RunningInputForm> {
                 gradient: isSelected
                     ? const LinearGradient(
                         colors: [Color(0xFF3B82F6), Color(0xFF1E40AF)],
-                      ,
+                      ),
                     : null,
                 border: Border.all(
                   color: isSelected
@@ -252,7 +252,7 @@ class _RunningInputFormState extends State<_RunningInputForm> {
             ),
           ),
         );
-      }).toList(,
+      }).toList(),
     );
   }
 
@@ -290,7 +290,7 @@ class _RunningInputFormState extends State<_RunningInputForm> {
               gradient: isSelected
                   ? const LinearGradient(
                       colors: [Color(0xFF3B82F6), Color(0xFF1E40AF)],
-                    ,
+                    ),
                   : null,
               border: Border.all(
                 color: isSelected
@@ -358,7 +358,7 @@ class _RunningInputFormState extends State<_RunningInputForm> {
               gradient: isSelected
                   ? const LinearGradient(
                       colors: [Color(0xFF3B82F6), Color(0xFF1E40AF)],
-                    ,
+                    ),
                   : null,
               border: Border.all(
                 color: isSelected
@@ -570,7 +570,7 @@ class _RunningFortuneResult extends StatelessWidget {
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/lucky_series_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/lucky_series_fortune_page.dart
@@ -23,7 +23,7 @@ class LuckySeriesFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _LuckySeriesFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -107,7 +107,7 @@ class _LuckySeriesInputFormState extends State<_LuckySeriesInputForm> {
         Text(
           '오늘 당신에게 행운을 가져다줄\n시리즈를 찾아보세요!',
           style: theme.textTheme.bodyLarge?.copyWith(
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.8)),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
             height: 1.5,
           ),
         ),
@@ -128,11 +128,11 @@ class _LuckySeriesInputFormState extends State<_LuckySeriesInputForm> {
             prefixIcon: const Icon(Icons.person_outline),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -151,12 +151,12 @@ class _LuckySeriesInputFormState extends State<_LuckySeriesInputForm> {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
             decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
               children: [
-                Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7),
                 const SizedBox(width: 12),
                 Text(
                   _birthDate != null
@@ -536,7 +536,7 @@ class _LuckySeriesFortuneResult extends ConsumerWidget {
                     Text(
                       avoidSeries['reason'],
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.7)),
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                         fontSize: 12 + fontSize,
                       ),
                     ),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/lucky_stock_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/lucky_stock_fortune_page.dart
@@ -21,7 +21,7 @@ class LuckyStockFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _LuckyStockFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -276,7 +276,7 @@ class _LuckyStockFortuneResult extends StatelessWidget {
             ),
           ],
         ],
-      ,
+      ),
     );
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/lucky_swim_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/lucky_swim_fortune_page.dart
@@ -52,7 +52,7 @@ class _SwimInputFormState extends State<_SwimInputForm> {
         Text(
           '오늘의 수영 운세를 확인하고\n물 속에서 행운을 만나보세요!',
           style: theme.textTheme.bodyLarge?.copyWith(
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.8)),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
             height: 1.5,
           ),
         ),
@@ -170,7 +170,7 @@ class _SwimInputFormState extends State<_SwimInputForm> {
               gradient: isSelected
                   ? const LinearGradient(
                       colors: [Color(0xFF06B6D4), Color(0xFF0891B2)],
-                    ,
+                    ),
                   : null,
               border: Border.all(
                 color: isSelected
@@ -238,7 +238,7 @@ class _SwimInputFormState extends State<_SwimInputForm> {
               gradient: isSelected
                   ? const LinearGradient(
                       colors: [Color(0xFF06B6D4), Color(0xFF0891B2)],
-                    ,
+                    ),
                   : null,
               border: Border.all(
                 color: isSelected
@@ -290,7 +290,7 @@ class _SwimInputFormState extends State<_SwimInputForm> {
                 gradient: isSelected
                     ? const LinearGradient(
                         colors: [Color(0xFF06B6D4), Color(0xFF0891B2)],
-                      ,
+                      ),
                     : null,
                 border: Border.all(
                   color: isSelected
@@ -311,7 +311,7 @@ class _SwimInputFormState extends State<_SwimInputForm> {
             ),
           ),
         );
-      }).toList(,
+      }).toList(),
     );
   }
 
@@ -349,7 +349,7 @@ class _SwimInputFormState extends State<_SwimInputForm> {
               gradient: isSelected
                   ? const LinearGradient(
                       colors: [Color(0xFF06B6D4), Color(0xFF0891B2)],
-                    ,
+                    ),
                   : null,
               border: Border.all(
                 color: isSelected
@@ -561,7 +561,7 @@ class _SwimFortuneResult extends StatelessWidget {
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/lucky_tennis_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/lucky_tennis_fortune_page.dart
@@ -257,7 +257,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             ],
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -595,7 +595,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -625,7 +625,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
               _buildShotItem(entry.value, index: entry.key)).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -712,7 +712,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             _buildEquipmentItem('신발', '쿠션이 좋은 신발 추천', Icons.sports_basketball),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -752,7 +752,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -783,7 +783,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             _buildStrategyItem('게임 운영', '중요한 포인트에서 안정적으로'),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -816,7 +816,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -851,7 +851,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -946,7 +946,7 @@ class _LuckyTennisFortunePageState extends BaseFortunePageState<LuckyTennisFortu
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/lucky_yoga_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/lucky_yoga_fortune_page.dart
@@ -21,7 +21,7 @@ class LuckyYogaFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _LuckyYogaFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -276,7 +276,7 @@ class _LuckyYogaFortuneResult extends StatelessWidget {
             ),
           ],
         ],
-      ,
+      ),
     );
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/marriage_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/marriage_fortune_page.dart
@@ -219,7 +219,7 @@ class _MarriageFortunePageState extends BaseFortunePageState<MarriageFortunePage
             ],
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -809,7 +809,7 @@ class _MarriageFortunePageState extends BaseFortunePageState<MarriageFortunePage
             )).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -900,7 +900,7 @@ class _MarriageFortunePageState extends BaseFortunePageState<MarriageFortunePage
             }).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -986,7 +986,7 @@ class _MarriageFortunePageState extends BaseFortunePageState<MarriageFortunePage
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -1117,7 +1117,7 @@ class _MarriageFortunePageState extends BaseFortunePageState<MarriageFortunePage
             }).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -1257,7 +1257,7 @@ class _MarriageFortunePageState extends BaseFortunePageState<MarriageFortunePage
             )).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/mbti_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/mbti_fortune_page.dart
@@ -373,7 +373,7 @@ class _MbtiFortunePageState extends BaseFortunePageState<MbtiFortunePage> with T
                     theme.colorScheme.primary,
                     theme.colorScheme.primary.withValues(alpha: 0.8),
                   ],
-                ,
+                ),
               : null,
           borderRadius: BorderRadius.circular(16),
         ),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/moving_date_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/moving_date_fortune_page.dart
@@ -24,7 +24,7 @@ class MovingDateFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _MovingDateFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -98,7 +98,7 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
         Text(
           '이사 가능한 날짜를 선택하시면\n최적의 이사 날짜를 추천해드립니다.',
           style: theme.textTheme.bodyLarge?.copyWith(
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.8)),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
             height: 1.5,
           ),
         ),
@@ -119,11 +119,11 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
             prefixIcon: const Icon(Icons.person_outline),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -142,12 +142,12 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
             decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
               children: [
-                Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7),
                 const SizedBox(width: 12),
                 Text(
                   _birthDate != null
@@ -180,11 +180,11 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
             prefixIcon: const Icon(Icons.location_on_outlined),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -205,11 +205,11 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
             prefixIcon: const Icon(Icons.location_searching),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -273,7 +273,7 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
                   decoration: BoxDecoration(
-                    border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                    border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -308,7 +308,7 @@ class _MovingDateInputFormState extends State<_MovingDateInputForm> {
                 child: Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
                   decoration: BoxDecoration(
-                    border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                    border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -613,7 +613,7 @@ class _MovingDateFortuneResultState extends ConsumerState<_MovingDateFortuneResu
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
-                          ,
+                          ),
                         );
                       }
                       return null;

--- a/fortune_flutter/lib/features/fortune/presentation/pages/moving_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/moving_fortune_page.dart
@@ -138,11 +138,11 @@ class _MovingInputFormState extends State<_MovingInputForm> {
             prefixIcon: const Icon(Icons.person_outline),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -161,12 +161,12 @@ class _MovingInputFormState extends State<_MovingInputForm> {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
             decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
               children: [
-                Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7),
                 const SizedBox(width: 12),
                 Text(
                   _birthDate != null
@@ -199,11 +199,11 @@ class _MovingInputFormState extends State<_MovingInputForm> {
             prefixIcon: const Icon(Icons.home_outlined),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -222,12 +222,12 @@ class _MovingInputFormState extends State<_MovingInputForm> {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
             decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
               children: [
-                Icon(Icons.event, color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                Icon(Icons.event, color: theme.colorScheme.primary.withValues(alpha: 0.7),
                 const SizedBox(width: 12),
                 Text(
                   _plannedDate != null
@@ -677,7 +677,7 @@ class _MovingFortuneResult extends ConsumerWidget {
                     Text(
                       avoidDirection['reason'],
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.7)),
+                        color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                         fontSize: 12 + fontSize,
                       ),
                     ),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/network_report_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/network_report_fortune_page.dart
@@ -24,7 +24,7 @@ class NetworkReportFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _NetworkReportFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -117,7 +117,7 @@ class _NetworkReportInputFormState extends State<_NetworkReportInputForm> {
           Text(
             '당신의 인맥 운세를 분석하고\n네트워킹 전략을 제시해드립니다.',
             style: theme.textTheme.bodyLarge?.copyWith(
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.8)),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
               height: 1.5,
             ),
           ),
@@ -138,11 +138,11 @@ class _NetworkReportInputFormState extends State<_NetworkReportInputForm> {
               prefixIcon: const Icon(Icons.person_outline),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
             ),
           ),
@@ -161,12 +161,12 @@ class _NetworkReportInputFormState extends State<_NetworkReportInputForm> {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Row(
                 children: [
-                  Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                  Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7),
                   const SizedBox(width: 12),
                   Text(
                     _birthDate != null
@@ -199,11 +199,11 @@ class _NetworkReportInputFormState extends State<_NetworkReportInputForm> {
               prefixIcon: const Icon(Icons.work_outline),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
             ),
           ),
@@ -381,7 +381,7 @@ class _NetworkReportInputFormState extends State<_NetworkReportInputForm> {
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 }
@@ -615,7 +615,7 @@ class _NetworkReportFortuneResult extends ConsumerWidget {
                                   Text(
                                     person['description'],
                                     style: theme.textTheme.bodyMedium?.copyWith(
-                                      color: theme.colorScheme.onSurface.withValues(alpha: 0.7)),
+                                      color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                                       fontSize: 12 + fontSize,
                                     ),
                                   ),
@@ -765,7 +765,7 @@ class _NetworkReportFortuneResult extends ConsumerWidget {
             showTitle: false,
           ),
         ],
-      ,
+      ),
     );
   }
   
@@ -795,7 +795,7 @@ class _NetworkReportFortuneResult extends ConsumerWidget {
         sectionsSpace: 2,
         centerSpaceRadius: 40,
         sections: sections,
-      ,
+      ),
     );
   }
   
@@ -872,7 +872,7 @@ class _NetworkReportFortuneResult extends ConsumerWidget {
           ),
         ),
         borderData: FlBorderData(show: false),
-      ,
+      ),
     );
   }
   

--- a/fortune_flutter/lib/features/fortune/presentation/pages/palmistry_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/palmistry_fortune_page.dart
@@ -321,7 +321,7 @@ class _PalmistryFortunePageState extends BaseFortunePageState<PalmistryFortunePa
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -500,7 +500,7 @@ class _PalmistryFortunePageState extends BaseFortunePageState<PalmistryFortunePa
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -654,7 +654,7 @@ class _PalmistryFortunePageState extends BaseFortunePageState<PalmistryFortunePa
             )).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -728,7 +728,7 @@ class _PalmistryFortunePageState extends BaseFortunePageState<PalmistryFortunePa
             }).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -828,7 +828,7 @@ class _PalmistryFortunePageState extends BaseFortunePageState<PalmistryFortunePa
             )).toList(),
           ],
         ),
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/past_life_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/past_life_fortune_page.dart
@@ -21,7 +21,7 @@ class PastLifeFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _PastLifeFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -276,7 +276,7 @@ class _PastLifeFortuneResult extends StatelessWidget {
             ),
           ],
         ],
-      ,
+      ),
     );
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_page.dart
@@ -24,7 +24,7 @@ class PersonalityFortunePage extends ConsumerWidget {
       resultBuilder: (context, result, onShare) => _PersonalityFortuneResult(
         result: result,
         onShare: onShare,
-      ,
+      ),
     );
   }
 }
@@ -131,11 +131,11 @@ class _PersonalityInputFormState extends State<_PersonalityInputForm> {
               prefixIcon: const Icon(Icons.person_outline),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
             ),
           ),
@@ -154,12 +154,12 @@ class _PersonalityInputFormState extends State<_PersonalityInputForm> {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+                border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Row(
                 children: [
-                  Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7)),
+                  Icon(Icons.calendar_today, color: theme.colorScheme.primary.withValues(alpha: 0.7),
                   const SizedBox(width: 12),
                   Text(
                     _birthDate != null
@@ -376,7 +376,7 @@ class _PersonalityInputFormState extends State<_PersonalityInputForm> {
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 }
@@ -898,7 +898,7 @@ class _PersonalityFortuneResult extends ConsumerWidget {
         borderColor: theme.colorScheme.primary,
         borderWidth: 2,
         dataEntries: values.map((v) => RadarEntry(value: v)).toList(),
-      ,
+      ),
     );
     
     return RadarChart(
@@ -931,7 +931,7 @@ class _PersonalityFortuneResult extends ConsumerWidget {
           color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
           fontSize: 10,
         ),
-      ,
+      ),
     );
   }
   

--- a/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_unified_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/personality_fortune_unified_page.dart
@@ -168,7 +168,7 @@ class _PersonalityFortuneUnifiedPageState extends BaseFortunePageState<Personali
             textAlign: TextAlign.center,
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -245,7 +245,7 @@ class _PersonalityFortuneUnifiedPageState extends BaseFortunePageState<Personali
               .slideX(begin: type == PersonalityType.mbti ? -0.2 : 0.2, end: 0),
           ),
         );
-      }).toList(,
+      }).toList(),
     );
   }
 
@@ -350,7 +350,7 @@ class _PersonalityFortuneUnifiedPageState extends BaseFortunePageState<Personali
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -520,7 +520,7 @@ class _PersonalityFortuneUnifiedPageState extends BaseFortunePageState<Personali
         style: TextButton.styleFrom(
           foregroundColor: _selectedType.gradientColors[0],
         ),
-      ,
+      ),
     );
   }
 
@@ -768,7 +768,7 @@ class _PersonalityFortuneUnifiedPageState extends BaseFortunePageState<Personali
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/pet_compatibility_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/pet_compatibility_page.dart
@@ -103,7 +103,7 @@ class _PetCompatibilityPageState extends BaseFortunePageState<PetCompatibilityPa
             child: Container(), // The base class handles the generate button
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -130,7 +130,7 @@ class _PetCompatibilityPageState extends BaseFortunePageState<PetCompatibilityPa
             child: const Text('로그인하기'),
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -216,7 +216,7 @@ class _PetCompatibilityPageState extends BaseFortunePageState<PetCompatibilityPa
             ),
           ],
         ),
-      ,
+      ),
     );
   }
 
@@ -408,7 +408,7 @@ class _PetCompatibilityPageState extends BaseFortunePageState<PetCompatibilityPa
             '칭찬과 보상으로 올바른 행동을 강화하세요',
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -451,7 +451,7 @@ class _PetCompatibilityPageState extends BaseFortunePageState<PetCompatibilityPa
             ),
           ),
         ],
-      ,
+      ),
     );
   }
 
@@ -501,7 +501,7 @@ class _PetCompatibilityPageState extends BaseFortunePageState<PetCompatibilityPa
             child: const Text('확인'),
           ),
         ],
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/pet_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/pet_fortune_page.dart
@@ -103,7 +103,7 @@ class _PetFortunePageState extends BaseFortunePageState<PetFortunePage> {
             right: 0)
             child: _buildGenerateButton(),
           )$1,
-      ,
+      ),
     );
   }
 
@@ -129,7 +129,7 @@ class _PetFortunePageState extends BaseFortunePageState<PetFortunePage> {
             onPressed: () => context.push('/onboarding'),
             child: const Text('로그인하기'),
           )$1,
-      ,
+      ),
     );
   }
 
@@ -224,7 +224,7 @@ class _PetFortunePageState extends BaseFortunePageState<PetFortunePage> {
                 )$1,
             )$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -292,7 +292,7 @@ class _PetFortunePageState extends BaseFortunePageState<PetFortunePage> {
                 )$1,
             ),
           )).toList()$1,
-      ,
+      ),
     );
   }
 
@@ -351,7 +351,7 @@ class _PetFortunePageState extends BaseFortunePageState<PetFortunePage> {
                     strokeWidth: 2)
                     valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                   ),
-                ,
+                ),
               : const Text(
                   '운세 보기',
                   style: TextStyle(
@@ -381,7 +381,7 @@ class _PetFortunePageState extends BaseFortunePageState<PetFortunePage> {
             onPressed: () => Navigator.of(context).pop(),
             child: const Text('확인'),
           )$1,
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/pet_fortune_unified_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/pet_fortune_unified_page.dart
@@ -120,7 +120,7 @@ class _PetFortuneUnifiedPageState extends BaseFortunePageState<PetFortuneUnified
       decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft,
-          end: Alignment.bottomRight)
+          end: Alignment.bottomRight,
           colors: [
             Color(0xFFE11D48).withValues(alpha: 0.1),
             Color(0xFF9333EA).withValues(alpha: 0.05)$1,
@@ -156,7 +156,7 @@ class _PetFortuneUnifiedPageState extends BaseFortunePageState<PetFortuneUnified
             ),
             textAlign: TextAlign.center,
           )$1,
-      ,
+      ),
     );
   }
 
@@ -367,7 +367,7 @@ class _PetFortuneUnifiedPageState extends BaseFortunePageState<PetFortuneUnified
         style: TextButton.styleFrom(
           foregroundColor: _selectedType.gradientColors[0])
         ),
-      ,
+      ),
     );
   }
 
@@ -393,7 +393,7 @@ class _PetFortuneUnifiedPageState extends BaseFortunePageState<PetFortuneUnified
       decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft,
-          end: Alignment.bottomRight)
+          end: Alignment.bottomRight,
           colors: [
             _selectedType.gradientColors[0].withValues(alpha: 0.1),
             _selectedType.gradientColors[1].withValues(alpha: 0.05)$1,

--- a/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_enhanced_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_enhanced_page.dart
@@ -44,7 +44,7 @@ class PhysiognomyEnhancedPage extends ConsumerWidget {
               ),
             )$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -137,7 +137,7 @@ class PhysiognomyEnhancedPage extends ConsumerWidget {
           ).animate()
             .fadeIn(duration: 600.ms, delay: 600.ms)
             .scale(begin: const Offset(0.8, 0.8), end: const Offset(1, 1))$1,
-      ,
+      ),
     );
   }
 
@@ -240,7 +240,7 @@ class PhysiognomyEnhancedPage extends ConsumerWidget {
                 Text(
                   '업로드된 사진은 분석 후 즉시 삭제되며,\n개인정보는 안전하게 보호됩니다.')
                   style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.7)),
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                     height: 1.4,
                   ),
                 )$1,

--- a/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_fortune_page.dart
@@ -535,7 +535,7 @@ class _PhysiognomyFortunePageState extends BaseFortunePageState<PhysiognomyFortu
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   begin: Alignment.topLeft,
-                  end: Alignment.bottomRight)
+                  end: Alignment.bottomRight,
                   colors: [
                     theme.colorScheme.primary.withValues(alpha: 0.1),
                     theme.colorScheme.secondary.withValues(alpha: 0.1)$1,
@@ -569,7 +569,7 @@ class _PhysiognomyFortunePageState extends BaseFortunePageState<PhysiognomyFortu
             const SizedBox(height: 12),
             _buildAnalysisScore('직업운', 90, '리더십과 창의성이 뛰어납니다')$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -688,7 +688,7 @@ class _PhysiognomyFortunePageState extends BaseFortunePageState<PhysiognomyFortu
               }).toList(),
             )$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -783,7 +783,7 @@ class _PhysiognomyFortunePageState extends BaseFortunePageState<PhysiognomyFortu
               ),
             )).toList()$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -862,7 +862,7 @@ class _PhysiognomyFortunePageState extends BaseFortunePageState<PhysiognomyFortu
               ),
             )).toList()$1,
         ),
-      ,
+      ),
     );
   }
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_input_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_input_page.dart
@@ -121,7 +121,7 @@ class _PhysiognomyInputPageState extends ConsumerState<PhysiognomyInputPage> {
               ),
             )$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -294,7 +294,7 @@ class _PhysiognomyInputPageState extends ConsumerState<PhysiognomyInputPage> {
                         ),
                       ),
                     )$1,
-                ,
+                ),
               : Column(
                   mainAxisAlignment: MainAxisAlignment.center)
                   children: [
@@ -642,7 +642,7 @@ class _PhysiognomyInputPageState extends ConsumerState<PhysiognomyInputPage> {
                 },
               ),
               ListTile(
-                leading: Icon(Icons.close, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
+                leading: Icon(Icons.close, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
                 title: const Text('취소'),
                 onTap: () => Navigator.pop(context),
               )$1,

--- a/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_result_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_result_page.dart
@@ -190,7 +190,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
               label: const Text('다시 시도'),
             )$1,
         ),
-      ,
+      ),
     );
   }
 
@@ -226,7 +226,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
           // Action Buttons
           _buildActionButtons(theme),
           const SizedBox(height: 32)$1,
-      ,
+      ),
     );
   }
 
@@ -270,7 +270,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                         progress: value)
                         color: _getScoreColor(score),
                         strokeWidth: 8,
-                      ,
+                      ),
                     );
                   },
                 ),
@@ -289,7 +289,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                           style: theme.textTheme.displayMedium?.copyWith(
                             fontWeight: FontWeight.bold)
                             color: _getScoreColor(score),
-                          ,
+                          ),
                         );
                       },
                     ),
@@ -326,7 +326,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
               textAlign: TextAlign.center,
             ),
           )$1,
-      ,
+      ),
     );
   }
 
@@ -436,7 +436,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
           
           // Feature analysis cards
           ..._buildFeatureAnalysis(theme, analysis)$1,
-      ,
+      ),
     );
   }
 
@@ -502,7 +502,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 ),
               )$1,
           ),
-        ,
+        ),
       );
     }).toList();
   }
@@ -577,7 +577,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
               ),
             );
           }).toList()$1,
-      ,
+      ),
     );
   }
 
@@ -659,7 +659,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
               ),
             );
           }).toList()$1,
-      ,
+      ),
     );
   }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/salpuli_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/salpuli_fortune_page.dart
@@ -528,7 +528,7 @@ class _SalpuliFortunePageState extends BaseFortunePageState<SalpuliFortunePage> 
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   begin: Alignment.topLeft,
-                  end: Alignment.bottomRight)
+                  end: Alignment.bottomRight,
                   colors: [
                     Colors.red.withValues(alpha: 0.1),
                     Colors.orange.withValues(alpha: 0.1)$1,
@@ -780,7 +780,7 @@ class _SalpuliFortunePageState extends BaseFortunePageState<SalpuliFortunePage> 
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
                     begin: Alignment.topLeft,
-                    end: Alignment.bottomRight)
+                    end: Alignment.bottomRight,
                     colors: [
                       theme.colorScheme.primary.withValues(alpha: 0.05),
                       theme.colorScheme.secondary.withValues(alpha: 0.05)$1,

--- a/fortune_flutter/lib/features/fortune/presentation/pages/same_birthday_celebrity_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/same_birthday_celebrity_fortune_page.dart
@@ -20,13 +20,15 @@ class SameBirthdayCelebrityFortunePage extends ConsumerWidget {
       fortuneType: 'same-birthday-celebrity',
       headerGradient: const LinearGradient(
         begin: Alignment.topLeft,
-        end: Alignment.bottomRight)
+        end: Alignment.bottomRight,
         colors: [Color(0xFFFF1744), Color(0xFFE91E63)],
       ),
       inputBuilder: (context, onSubmit) => _SameBirthdayInputForm(onSubmit: onSubmit),
       resultBuilder: (context, result, onShare) => _SameBirthdayFortuneResult(
-        result: result)
-        onShare: onShare);
+        result: result,
+        onShare: onShare,
+      ),
+    );
   }
 }
 
@@ -82,11 +84,11 @@ class _SameBirthdayInputFormState extends ConsumerState<_SameBirthdayInputForm> 
             prefixIcon: const Icon(Icons.person_outline),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
             enabledBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.3),
             ),
           ),
         ),
@@ -130,7 +132,7 @@ class _SameBirthdayInputFormState extends ConsumerState<_SameBirthdayInputForm> 
           child: Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3)),
+              border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
@@ -365,7 +367,7 @@ class _SameBirthdayFortuneResult extends ConsumerWidget {
             GlassContainer(
               gradient: LinearGradient(
                 begin: Alignment.topLeft)
-                end: Alignment.bottomRight)
+                end: Alignment.bottomRight,
                 colors: [
                   theme.colorScheme.primary.withValues(alpha: 0.15),
                   theme.colorScheme.secondary.withValues(alpha: 0.1)$1,
@@ -596,7 +598,7 @@ class _SameBirthdayFortuneResult extends ConsumerWidget {
             GlassContainer(
               gradient: LinearGradient(
                 begin: Alignment.topLeft)
-                end: Alignment.bottomRight)
+                end: Alignment.bottomRight,
                 colors: [
                   Colors.purple.withValues(alpha: 0.1),
                   Colors.pink.withValues(alpha: 0.05)$1,
@@ -640,7 +642,7 @@ class _SameBirthdayFortuneResult extends ConsumerWidget {
     return GlassContainer(
       gradient: LinearGradient(
         begin: Alignment.topLeft,
-        end: Alignment.bottomRight)
+        end: Alignment.bottomRight,
         colors: [
           backgroundColor)
           backgroundColor.withValues(alpha: 0.5)$1,
@@ -678,7 +680,7 @@ class _SameBirthdayFortuneResult extends ConsumerWidget {
     return GlassContainer(
       gradient: LinearGradient(
         begin: Alignment.topLeft)
-        end: Alignment.bottomRight)
+        end: Alignment.bottomRight,
         colors: [
           color.withValues(alpha: 0.1),
           color.withValues(alpha: 0.05)$1,

--- a/fortune_flutter/lib/features/fortune/presentation/pages/sports_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/sports_fortune_page.dart
@@ -351,7 +351,7 @@ class _SportsFortunePageState extends BaseFortunePageState<SportsFortunePage> {
         decoration: BoxDecoration(
           gradient: LinearGradient(
             begin: Alignment.topLeft,
-            end: Alignment.bottomRight)
+            end: Alignment.bottomRight,
             colors: [
               _getSportColor(_selectedType).withValues(alpha: 0.1),
               _getSportColor(_selectedType).withValues(alpha: 0.05)$1,

--- a/fortune_flutter/lib/features/fortune/presentation/pages/startup_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/startup_fortune_page.dart
@@ -186,7 +186,7 @@ class StartupFortunePage extends ConsumerWidget {
           gradient: LinearGradient(
             colors: [Colors.purple.shade50, Colors.indigo.shade50],
             begin: Alignment.topLeft,
-            end: Alignment.bottomRight)
+            end: Alignment.bottomRight,
           ),
         ),
         child: Column(

--- a/fortune_flutter/lib/features/fortune/presentation/pages/talent_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/talent_fortune_page.dart
@@ -14,13 +14,14 @@ class TalentFortunePage extends ConsumerWidget {
       fortuneType: 'talent',
       headerGradient: const LinearGradient(
         begin: Alignment.topLeft,
-        end: Alignment.bottomRight)
+        end: Alignment.bottomRight,
         colors: [Color(0xFFFFB300), Color(0xFFFF8F00)],
       ),
       inputBuilder: (context, onSubmit) => _TalentInputForm(onSubmit: onSubmit),
       resultBuilder: (context, result, onShare) => _TalentFortuneResult(
-        result: result)
-        onShare: onShare);
+        result: result,
+        onShare: onShare,
+      );
   }
 }
 
@@ -39,7 +40,7 @@ class _TalentInputForm extends StatelessWidget {
         Text(
           '당신의 숨겨진 재능을 발견해보세요!\n잠재력과 발전 가능성을 알려드립니다.')
           style: theme.textTheme.bodyLarge?.copyWith(
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.8)),
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
             height: 1.5,
           ),
         ),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/talisman_enhanced_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/talisman_enhanced_page.dart
@@ -190,7 +190,7 @@ class _TalismanEnhancedPageState extends ConsumerState<TalismanEnhancedPage>
                         selectedType: state.selectedType!
                         onNext: _handleNextStep,
                         onBack: _handlePreviousStep,
-                      ,
+                      ),
                     : const Center(
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center)
@@ -285,7 +285,7 @@ class _TalismanEnhancedPageState extends ConsumerState<TalismanEnhancedPage>
                       Icons.check,
                       size: 16
                       color: Colors.white,
-                    ,
+                    ),
                   : Text(
                       '$step',
                       style: TextStyle(

--- a/fortune_flutter/lib/features/fortune/presentation/pages/talisman_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/talisman_fortune_page.dart
@@ -14,13 +14,14 @@ class TalismanFortunePage extends ConsumerWidget {
       fortuneType: 'talisman',
       headerGradient: const LinearGradient(
         begin: Alignment.topLeft,
-        end: Alignment.bottomRight)
+        end: Alignment.bottomRight,
         colors: [Color(0xFF8D6E63), Color(0xFF6D4C41)],
       ),
       inputBuilder: (context, onSubmit) => _TalismanInputForm(onSubmit: onSubmit),
       resultBuilder: (context, result, onShare) => _TalismanFortuneResult(
-        result: result)
-        onShare: onShare);
+        result: result,
+        onShare: onShare,
+      );
   }
 }
 

--- a/fortune_flutter/lib/features/fortune/presentation/pages/talisman_result_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/talisman_result_page.dart
@@ -116,7 +116,7 @@ class _TalismanResultPageState extends ConsumerState<TalismanResultPage>
                     width: 24,
                     height: 24,
                     child: CircularProgressIndicator(strokeWidth: 2),
-                  ,
+                  ),
                 : const Icon(Icons.share),
             onPressed: _isCapturing ? null : _captureTalisman,
           ),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/talisman_steps/talisman_generation_step.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/talisman_steps/talisman_generation_step.dart
@@ -241,7 +241,7 @@ class _TalismanGenerationStepState extends ConsumerState<TalismanGenerationStep>
                                 color: Colors.white,
                                 size: 50,
                               )).animate(onPlay: (controller) => controller.repeat())
-                              .shimmer(duration: 2000.ms, color: Colors.white.withValues(alpha: 0.3))
+                              .shimmer(duration: 2000.ms, color: Colors.white.withValues(alpha: 0.3)
                               .scale(
                                 begin: const Offset(0.9, 0.9),
                                 end: const Offset(1.1, 1.1),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/tarot_deck_selection_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/tarot_deck_selection_page.dart
@@ -259,7 +259,7 @@ class _TarotDeckSelectionPageState extends ConsumerState<TarotDeckSelectionPage>
 }
                 },
                 selectedColor: level.color.withValues(alpha: 0.3),
-                backgroundColor: Colors.white.withValues(alpha: 0.1));
+                backgroundColor: Colors.white.withValues(alpha: 0.1);
 }).toList(),
         ],
       ));

--- a/fortune_flutter/lib/features/fortune/presentation/pages/tarot_enhanced_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/tarot_enhanced_page.dart
@@ -152,7 +152,7 @@ class _MysticalBackground extends StatelessWidget {
       decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft),
-                  end: Alignment.bottomRight),
+                  end: Alignment.bottomRight,,
                   colors: [
             Colors.deepPurple.withValues(alpha: 0.05),
             Colors.indigo.withValues(alpha: 0.05),
@@ -496,7 +496,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
           color: Colors.purple.withValues(alpha: 0.2),
           borderRadius: BorderRadius.circular(4),
-          border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
+          border: Border.all(color: Colors.purple.withValues(alpha: 0.5),
       
     );
 }
@@ -512,7 +512,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
             color: Colors.purple.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(4),
-            border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
+            border: Border.all(color: Colors.purple.withValues(alpha: 0.5),
         ))));
 }
 
@@ -528,7 +528,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
               color: Colors.purple.withValues(alpha: 0.2),
               borderRadius: BorderRadius.circular(2),
-              border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
+              border: Border.all(color: Colors.purple.withValues(alpha: 0.5),
           ),
         Positioned(
           left: -25,
@@ -538,7 +538,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
               color: Colors.purple.withValues(alpha: 0.2),
               borderRadius: BorderRadius.circular(2),
-              border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
+              border: Border.all(color: Colors.purple.withValues(alpha: 0.5),
           ),
         Positioned(
           right: -25,
@@ -548,7 +548,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
               color: Colors.purple.withValues(alpha: 0.2),
               borderRadius: BorderRadius.circular(2),
-              border: Border.all(color: Colors.purple.withValues(alpha: 0.5)),
+              border: Border.all(color: Colors.purple.withValues(alpha: 0.5),
           ))
     );
 }
@@ -563,18 +563,18 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
             color: Colors.pink.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(4),
-            border: Border.all(color: Colors.pink.withValues(alpha: 0.5)),
+            border: Border.all(color: Colors.pink.withValues(alpha: 0.5),
         ),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 8),
-          child: Icon(Icons.favorite, size: 20, color: Colors.pink.withValues(alpha: 0.5)),
+          child: Icon(Icons.favorite, size: 20, color: Colors.pink.withValues(alpha: 0.5),
         Container(
           width: 25),
                   height: 38),
                   decoration: BoxDecoration(
             color: Colors.pink.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(4),
-            border: Border.all(color: Colors.pink.withValues(alpha: 0.5)),
+            border: Border.all(color: Colors.pink.withValues(alpha: 0.5),
         ));
 }
 
@@ -588,7 +588,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
             color: Colors.blue.withValues(alpha: 0.2),
             borderRadius: BorderRadius.circular(4),
-            border: Border.all(color: Colors.blue.withValues(alpha: 0.5)),
+            border: Border.all(color: Colors.blue.withValues(alpha: 0.5),
         ),
         SizedBox(height: 4),
         Row(
@@ -600,7 +600,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
                 color: Colors.green.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(4),
-                border: Border.all(color: Colors.green.withValues(alpha: 0.5)),
+                border: Border.all(color: Colors.green.withValues(alpha: 0.5),
             ),
             SizedBox(width: 8),
             Container(
@@ -609,7 +609,7 @@ class _SpreadOptionCard extends StatelessWidget {
                   decoration: BoxDecoration(
                 color: Colors.orange.withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(4),
-                border: Border.all(color: Colors.orange.withValues(alpha: 0.5)),
+                border: Border.all(color: Colors.orange.withValues(alpha: 0.5),
             ),
     );
 }

--- a/fortune_flutter/lib/features/fortune/presentation/pages/tarot_main_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/tarot_main_page.dart
@@ -486,7 +486,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
                                     borderRadius: BorderRadius.circular(16),
                                     gradient: LinearGradient(
                                       begin: Alignment.topLeft,
-                                      end: Alignment.bottomRight),
+                                      end: Alignment.bottomRight,,
                   colors: [
                                         (() {
                                           final alpha = 0.8;
@@ -635,7 +635,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
                           ? Opacity(
                               opacity: (_cardFlipController.value - 0.3) / 0.7,
                               child: _buildAnimatedBackground(),
-                            ,
+                            ),
                           : null
                     );
 },
@@ -835,7 +835,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
           borderRadius: BorderRadius.circular(20),
           gradient: LinearGradient(
             begin: Alignment.topLeft,
-            end: Alignment.bottomRight),
+            end: Alignment.bottomRight,,
                   colors: [
               color.withValues(alpha: 0.8),
               color,
@@ -968,7 +968,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
           borderRadius: BorderRadius.circular(8),
           gradient: LinearGradient(
             begin: Alignment.topLeft,
-            end: Alignment.bottomRight),
+            end: Alignment.bottomRight,,
                   colors: [
               const Color(0xFF1E3A5F),
               const Color(0xFF0D1B2A),
@@ -1023,7 +1023,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
         borderRadius: BorderRadius.circular(20),
         gradient: LinearGradient(
           begin: Alignment.topLeft,
-          end: Alignment.bottomRight),
+          end: Alignment.bottomRight,,
                   colors: [
             const Color(0xFF1E3A5F),
             const Color(0xFF0D1B2A),
@@ -1198,7 +1198,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topCenter),
-                  end: Alignment.bottomCenter),
+                  end: Alignment.bottomCenter,,
                   colors: [
                   Colors.black.withValues(alpha: 0.9),
                   Colors.black.withValues(alpha: 0.7),
@@ -1607,7 +1607,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
                             decoration: BoxDecoration(
                               gradient: LinearGradient(
                                 begin: Alignment.topLeft),
-                  end: Alignment.bottomRight),
+                  end: Alignment.bottomRight,,
                   colors: [
                                   color.withValues(alpha: 0.9),
                                   color.withValues(alpha: 0.7),
@@ -1619,7 +1619,7 @@ class _TarotMainPageState extends ConsumerState<TarotMainPage>
                               decoration: BoxDecoration(
                                 gradient: LinearGradient(
                                   begin: Alignment.topLeft,
-                                  end: Alignment.bottomRight),
+                                  end: Alignment.bottomRight,,
                   colors: [
                                     Colors.white.withValues(alpha: 0.25),
                                     Colors.white.withValues(alpha: 0.15),

--- a/fortune_flutter/lib/features/fortune/presentation/pages/tarot_storytelling_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/tarot_storytelling_page.dart
@@ -641,7 +641,7 @@ class _TarotStorytellingPageState extends ConsumerState<TarotStorytellingPage>
                     child: const CircularProgressIndicator(
                       strokeWidth: 2),
                   valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                  ,
+                  ),
                 else if (onPressed != null), Icon(
                     _currentCardIndex == widget.selectedCards.length - 1 && _showInterpretation
                         ? Icons.auto_awesome

--- a/fortune_flutter/lib/features/fortune/presentation/pages/time_based_fortune_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/time_based_fortune_page.dart
@@ -333,7 +333,7 @@ class _TimeBasedFortunePageState extends BaseFortunePageState<TimeBasedFortunePa
             decoration: BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topLeft,
-                end: Alignment.bottomRight),
+                end: Alignment.bottomRight,,
                   colors: [
                   AppTheme.primaryColor.withValues(alpha: 0.1),
                   AppTheme.primaryColor.withValues(alpha: 0.05),
@@ -495,7 +495,7 @@ class _TimeBasedFortunePageState extends BaseFortunePageState<TimeBasedFortunePa
         decoration: BoxDecoration(
           gradient: LinearGradient(
             begin: Alignment.topLeft,
-            end: Alignment.bottomRight),
+            end: Alignment.bottomRight,,
                   colors: [
               AppTheme.primaryColor.withValues(alpha: 0.1),
               AppTheme.primaryColor.withValues(alpha: 0.05),


### PR DESCRIPTION
## Summary
- fix bracket and comma issues in many fortune presentation pages
- run automated regex script to clean syntax

## Testing
- `dart analyze lib/features/fortune/presentation/pages/lucky_running_fortune_page.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c5cad45a4832fbf06c90ce7ef1dbe