### PR TITLE
Fix syntax errors in admin pages

### DIFF
--- a/fortune_flutter/lib/features/admin/presentation/pages/admin_dashboard_page.dart
+++ b/fortune_flutter/lib/features/admin/presentation/pages/admin_dashboard_page.dart
@@ -725,14 +725,14 @@ class _StatItem extends StatelessWidget {
         Text(
           label,
           style: TextStyle(
-            fontSize: 10 * fontScale),
+            fontSize: 10 * fontScale,
             color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
           ),
         ),
         Text(
           value,
           style: TextStyle(
-            fontSize: 12 * fontScale),
+            fontSize: 12 * fontScale,
             fontWeight: FontWeight.bold,
             color: color,
           ),
@@ -855,7 +855,7 @@ class _PackageAnalysisTab extends StatelessWidget {
                 Text(
                   '총 절감액',
                   style: TextStyle(
-                    fontSize: 16 * fontScale),
+                    fontSize: 16 * fontScale,
                     fontWeight: FontWeight.bold,
                   ),
                 ),
@@ -913,7 +913,7 @@ class _PackageStat extends StatelessWidget {
         Text(
           label,
           style: TextStyle(
-            fontSize: 10 * fontScale),
+            fontSize: 10 * fontScale,
             color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
           ),
         ),
@@ -921,7 +921,7 @@ class _PackageStat extends StatelessWidget {
         Text(
           value,
           style: TextStyle(
-            fontSize: 14 * fontScale),
+            fontSize: 14 * fontScale,
             fontWeight: FontWeight.bold,
           ),
         ),
@@ -967,7 +967,7 @@ class _TopUsersTab extends StatelessWidget {
           Text(
             '토큰 사용량 기준 상위 ${stats.topUsers.length}명',
             style: TextStyle(
-              fontSize: 14 * fontScale),
+              fontSize: 14 * fontScale,
               color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
             ),
           ),

--- a/fortune_flutter/lib/features/admin/presentation/pages/redis_monitor_page.dart
+++ b/fortune_flutter/lib/features/admin/presentation/pages/redis_monitor_page.dart
@@ -167,13 +167,14 @@ class _RedisMonitorPageState extends ConsumerState<RedisMonitorPage> {
               Text(
                 '${connection.activeConnections}/${connection.totalConnections}',
                 style: theme.textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.bold),
+                  fontWeight: FontWeight.bold,
                 ),
               ),
               Text(
                 '활성 연결',
                 style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
               ),
             ],
           ),
@@ -199,7 +200,7 @@ class _RedisMonitorPageState extends ConsumerState<RedisMonitorPage> {
                   center: Text(
                     '${cache.hitRate.toStringAsFixed(1)}%',
                     style: theme.textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold),
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
                   progressColor: theme.colorScheme.primary,
@@ -385,7 +386,7 @@ class _RedisMonitorPageState extends ConsumerState<RedisMonitorPage> {
           Text(
             '레이트 리밋 현황',
             style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold),
+              fontWeight: FontWeight.bold,
             ),
           ),
           const SizedBox(height: 16),
@@ -404,7 +405,7 @@ class _RedisMonitorPageState extends ConsumerState<RedisMonitorPage> {
                       Text(
                         info.tier.toUpperCase(),
                         style: theme.textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.bold),
+                          fontWeight: FontWeight.bold,
                         ),
                       ),
                       Text(
@@ -425,8 +426,8 @@ class _RedisMonitorPageState extends ConsumerState<RedisMonitorPage> {
                   Text(
                     '재설정: ${_formatResetTime(info.resetAt)}',
                     style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
-                  ),
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
                 ],
               ),
             );

--- a/fortune_flutter/lib/features/admin/presentation/pages/token_usage_stats_page.dart
+++ b/fortune_flutter/lib/features/admin/presentation/pages/token_usage_stats_page.dart
@@ -263,12 +263,12 @@ class TokenUsageStatsPage extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '운세별 사용량 TOP 10',
-            style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold),
+            Text(
+              '운세별 사용량 TOP 10',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
-          ),
           const SizedBox(height: 16),
           ...topTypes.map((type) => Padding(
             padding: const EdgeInsets.only(bottom: 12),
@@ -285,7 +285,8 @@ class TokenUsageStatsPage extends ConsumerWidget {
                       Text(
                         type.fortuneCategory,
                         style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
+                          color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                        ),
                       ),
                     ],
                   ),
@@ -329,7 +330,7 @@ class TokenUsageStatsPage extends ConsumerWidget {
           Text(
             '패키지 효율성',
             style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold),
+              fontWeight: FontWeight.bold,
             ),
           ),
           const SizedBox(height: 16),
@@ -428,7 +429,7 @@ class TokenUsageStatsPage extends ConsumerWidget {
           Text(
             '상위 사용자',
             style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold),
+              fontWeight: FontWeight.bold,
             ),
           ),
           const SizedBox(height: 16),
@@ -455,8 +456,9 @@ class TokenUsageStatsPage extends ConsumerWidget {
                         ),
                         Text(
                           user.email,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurface.withValues(alpha: 0.5)),
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                            ),
                         ),
                       ],
                     ),
@@ -566,7 +568,7 @@ class _InfoCard extends StatelessWidget {
           Text(
             value,
             style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold),
+              fontWeight: FontWeight.bold,
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- fix TextStyle parenthesis in admin dashboard
- correct style copyWith parameters in redis monitor page
- clean up style commas in token usage stats page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c5cbcca88832fae9fd512592ffc86