### PR TITLE
Fix color opacity method in profile screen

### DIFF
--- a/fortune_flutter/lib/screens/profile/profile_screen.dart
+++ b/fortune_flutter/lib/screens/profile/profile_screen.dart
@@ -448,7 +448,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 borderRadius: BorderRadius.circular(16),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.04),
+                    color: Colors.black.withOpacity(0.04),
                     blurRadius: 10,
                     offset: const Offset(0, 2),
                   ),
@@ -460,7 +460,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                   Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
-                      color: AppColors.primary.withValues(alpha: 0.05),
+                      color: AppColors.primary.withOpacity(0.05),
                       borderRadius: const BorderRadius.only(
                         topLeft: Radius.circular(16),
                         topRight: Radius.circular(16),
@@ -786,7 +786,7 @@ https://fortune.app''';
                     width: 40,
                     height: 40,
                     decoration: BoxDecoration(
-                      color: AppColors.primary.withValues(alpha: 0.1),
+                      color: AppColors.primary.withOpacity(0.1),
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Icon(


### PR DESCRIPTION
## Summary
- fix incorrect color `withValues` calls in profile screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c7862d5d0832fa46edf3620b00e7d