### PR TITLE
Fix syntax errors in physiognomy result page

### DIFF
--- a/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_result_page.dart
+++ b/fortune_flutter/lib/features/fortune/presentation/pages/physiognomy_result_page.dart
@@ -37,9 +37,9 @@ final physiognomyResultProvider = FutureProvider.family<Fortune, PhysiognomyData
   if (data.earType != null) params['earType'] = data.earType;
   
   return await fortuneService.getFortune(
-    fortuneType: 'physiognomy')
-    userId: user?.id ?? 'anonymous')
-    params: params
+    fortuneType: 'physiognomy',
+    userId: user?.id ?? 'anonymous',
+    params: params,
   );
 });
 
@@ -86,7 +86,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final fortuneAsync = ref.watch(physiognomyResultProvider(widget.data);
+    final fortuneAsync = ref.watch(physiognomyResultProvider(widget.data));
     
     return Scaffold(
       backgroundColor: theme.colorScheme.surface,
@@ -94,12 +94,13 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
         child: Column(
           children: [
             AppHeader(
-              title: '관상 분석 결과')
+              title: '관상 분석 결과',
               actions: [
                 IconButton(
                   icon: const Icon(Icons.share_rounded),
                   onPressed: _shareResult,
-                )$1,
+                ),
+              ],
             ),
             Expanded(
               child: fortuneAsync.when(
@@ -107,7 +108,8 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 loading: () => _buildLoadingState(theme),
                 error: (error, stack) => _buildErrorState(theme),
               ),
-            )$1,
+            ),
+          ],
         ),
       ),
     );
@@ -125,14 +127,15 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
               shape: BoxShape.circle,
               gradient: LinearGradient(
                 colors: [
-                  theme.colorScheme.primary)
-                  theme.colorScheme.secondary$1)
+                  theme.colorScheme.primary,
+                  theme.colorScheme.secondary,
+                ],
               ),
             ),
             child: const Icon(
               Icons.auto_awesome_rounded,
-              color: Colors.white)
-              size: 60)
+              color: Colors.white,
+              size: 60,
             ),
           ).animate(
             onPlay: (controller) => controller.repeat(),
@@ -141,18 +144,19 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
           const SizedBox(height: 24),
           
           Text(
-            'AI가 관상을 분석하고 있습니다...')
-            style: theme.textTheme.titleLarge)
+            'AI가 관상을 분석하고 있습니다...',
+            style: theme.textTheme.titleLarge,
           ),
           
           const SizedBox(height: 8),
           
           Text(
-            '잠시만 기다려주세요')
+            '잠시만 기다려주세요',
             style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+              color: theme.colorScheme.onSurface.withOpacity(0.7),
             ),
-          )$1,
+          ),
+        ],
       ),
     );
   }
@@ -165,31 +169,32 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(
-              Icons.error_outline_rounded)
-              size: 64)
-              color: theme.colorScheme.error)
+              Icons.error_outline_rounded,
+              size: 64,
+              color: theme.colorScheme.error,
             ),
             const SizedBox(height: 16),
             Text(
-              '분석 중 오류가 발생했습니다')
-              style: theme.textTheme.titleLarge)
+              '분석 중 오류가 발생했습니다',
+              style: theme.textTheme.titleLarge,
             ),
             const SizedBox(height: 8),
             Text(
-              '다시 시도해주세요')
+              '다시 시도해주세요',
               style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                color: theme.colorScheme.onSurface.withOpacity(0.7),
               ),
             ),
             const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              icon: const Icon(Icons.refresh_rounded),
-              label: const Text('다시 시도'),
-            )$1,
-        ),
+              ElevatedButton.icon(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                icon: const Icon(Icons.refresh_rounded),
+                label: const Text('다시 시도'),
+              ),
+            ],
+          ),
       ),
     );
   }
@@ -225,7 +230,8 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
           
           // Action Buttons
           _buildActionButtons(theme),
-          const SizedBox(height: 32)$1,
+          const SizedBox(height: 32),
+        ],
       ),
     );
   }
@@ -235,8 +241,8 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
       child: Column(
         children: [
           Text(
-            '종합 관상 점수')
-            style: theme.textTheme.titleLarge)
+            '종합 관상 점수',
+            style: theme.textTheme.titleLarge,
           ),
           const SizedBox(height: 16),
           
@@ -245,12 +251,12 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
             width: 180,
             height: 180,
             child: Stack(
-              alignment: Alignment.center)
+              alignment: Alignment.center,
               children: [
                 // Background circle
                 Container(
                   decoration: BoxDecoration(
-                    shape: BoxShape.circle)
+                    shape: BoxShape.circle,
                     border: Border.all(
                       color: theme.colorScheme.onSurface.withValues(alpha: 0.1),
                       width: 4,
@@ -267,7 +273,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                     return CustomPaint(
                       size: const Size(180, 180),
                       painter: CircularProgressPainter(
-                        progress: value)
+                        progress: value,
                         color: _getScoreColor(score),
                         strokeWidth: 8,
                       ),
@@ -277,7 +283,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 
                 // Score text
                 Column(
-                  mainAxisSize: MainAxisSize.min)
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     TweenAnimationBuilder<int>(
                       tween: IntTween(begin: 0, end: score),
@@ -285,9 +291,9 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                       curve: Curves.easeOutCubic,
                       builder: (context, value, child) {
                         return Text(
-                          '$value')
+                          '$value',
                           style: theme.textTheme.displayMedium?.copyWith(
-                            fontWeight: FontWeight.bold)
+                            fontWeight: FontWeight.bold,
                             color: _getScoreColor(score),
                           ),
                         );
@@ -296,10 +302,11 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                     Text(
                       _getScoreDescription(score),
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                        color: theme.colorScheme.onSurface.withOpacity(0.7),
                       ),
-                    )$1,
-                )$1,
+                    ),
+                  ],
+                ),
             ),
           ).animate()
             .scale(
@@ -325,7 +332,8 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
               ),
               textAlign: TextAlign.center,
             ),
-          )$1,
+          ),
+        ],
       ),
     );
   }
@@ -351,16 +359,16 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 Row(
                   children: [
                     Container(
-                      width: 40)
-                      height: 40)
+                      width: 40,
+                      height: 40,
                       decoration: BoxDecoration(
                         color: theme.colorScheme.primary.withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Icon(
                         category['icon'] as IconData,
-                        color: theme.colorScheme.primary)
-                        size: 24)
+                        color: theme.colorScheme.primary,
+                        size: 24,
                       ),
                     ),
                     const SizedBox(width: 12),
@@ -369,21 +377,21 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween)
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Text(
-                                category['name'] as String)
+                                category['name'] as String,
                                 style: theme.textTheme.bodyLarge?.copyWith(
-                                  fontWeight: FontWeight.bold)
+                                  fontWeight: FontWeight.bold,
                                 ),
                               ),
                               Text(
-                                '${category['score']}점')
+                                '${category['score']}점',
                                 style: theme.textTheme.bodyLarge?.copyWith(
                                   color: _getScoreColor(category['score'] as int),
                                   fontWeight: FontWeight.bold,
                                 ),
-                              )$1,
+                              ),
                           ),
                           const SizedBox(height: 8),
                           TweenAnimationBuilder<double>(
@@ -400,10 +408,10 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                                 minHeight: 6
                               );
                             },
-                          )$1,
+                          ),
                       ),
-                    )$1,
-                )$1,
+                    ),
+                ),
             ),
           ),
         ).animate()
@@ -430,12 +438,12 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 style: theme.textTheme.titleLarge?.copyWith(
                   fontWeight: FontWeight.bold)
                 ),
-              )$1,
+              ),
           ),
           const SizedBox(height: 16),
           
           // Feature analysis cards
-          ..._buildFeatureAnalysis(theme, analysis)$1,
+          ..._buildFeatureAnalysis(theme, analysis),
       ),
     );
   }
@@ -460,8 +468,9 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
       {
         'part': '입',
         'analysis': analysis['mouth'] ?? '따뜻한 미소가 인상적이며 대인관계가 원만합니다.',
-        'icon': Icons.mood_rounded
-      }$1;
+        'icon': Icons.mood_rounded,
+      },
+    ];
     
     return features.map((feature) {
       return Padding(
@@ -498,9 +507,9 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                         color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
                         height: 1.4,
                       ),
-                    )$1,
+                    ),
                 ),
-              )$1,
+              ),
           ),
         ),
       );
@@ -514,7 +523,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
       {'trait': '공감능력', 'level': 0.7, 'color': Colors.pink},
       {'trait': '분석력', 'level': 0.85, 'color': Colors.orange},
       {'trait': '인내심', 'level': 0.75, 'color': Colors.green},
-      {'trait': '소통능력', 'level': 0.95, 'color': Colors.teal}$1;
+      {'trait': '소통능력', 'level': 0.95, 'color': Colors.teal},
     
     return GlassContainer(
       child: Column(
@@ -532,7 +541,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 style: theme.textTheme.titleLarge?.copyWith(
                   fontWeight: FontWeight.bold)
                 ),
-              )$1,
+              ),
           ),
           const SizedBox(height: 16),
           
@@ -558,7 +567,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                           color: trait['color'] as Color)
                           fontWeight: FontWeight.bold)
                         ),
-                      )$1,
+                      ),
                   ),
                   const SizedBox(height: 4),
                   TweenAnimationBuilder<double>(
@@ -573,10 +582,10 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                         minHeight: 8,
                       );
                     },
-                  )$1,
+                  ),
               ),
             );
-          }).toList()$1,
+          }).toList(),
       ),
     );
   }
@@ -586,19 +595,24 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
       {
         'category': '재물',
         'advice': '40대 중반에 큰 재물운이 있으니 그때를 위해 준비하세요.',
-        'color': Colors.amber$1,
+        'color': Colors.amber,
+      },
       {
         'category': '건강',
         'advice': '스트레스 관리에 신경 쓰고, 규칙적인 운동을 하세요.',
-        'color': Colors.green$1,
+        'color': Colors.green,
+      },
       {
         'category': '인연',
         'advice': '진실한 마음으로 대하면 좋은 인연을 만날 수 있습니다.',
-        'color': Colors.pink$1,
+        'color': Colors.pink,
+      },
       {
         'category': '직업',
         'advice': '창의적인 분야나 리더십을 발휘할 수 있는 직종이 적합합니다.',
-        'color': Colors.blue$1$1;
+        'color': Colors.blue,
+      },
+    ];
     
     return GlassContainer(
       child: Column(
@@ -616,7 +630,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                 style: theme.textTheme.titleLarge?.copyWith(
                   fontWeight: FontWeight.bold)
                 ),
-              )$1,
+              ),
           ),
           const SizedBox(height: 16),
           
@@ -653,12 +667,12 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
                             color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
                             height: 1.4,
                           ),
-                        )$1,
+                        ),
                     ),
-                  )$1,
+                  ),
               ),
             );
-          }).toList()$1,
+          }).toList(),
       ),
     );
   }
@@ -701,7 +715,7 @@ class _PhysiognomyResultPageState extends ConsumerState<PhysiognomyResultPage>
             ),
           ),
           child: const Text('다시 분석하기'),
-        )$1
+        )
     );
   }
 
@@ -748,11 +762,12 @@ AI가 분석한 나의 관상이 궁금하다면?
     // Parse scores from fortune content
     // This is a simplified version - implement actual parsing logic
     return {
-      'overall': 85
+      'overall': 85,
       'wealth': 80,
       'love': 75,
       'health': 85,
-      'business': 70$1;
+      'business': 70,
+    };
   }
 
   Map<String, String> _parseAnalysis(String content) {
@@ -762,7 +777,8 @@ AI가 분석한 나의 관상이 궁금하다면?
       'forehead': '넓고 시원한 이마는 지적 능력과 창의성을 나타냅니다.',
       'eyes': '맑고 깊은 눈은 예리한 관찰력과 통찰력을 보여줍니다.',
       'nose': '균형 잡힌 코는 재물운과 건강운이 좋음을 나타냅니다.',
-      'mouth': '따뜻한 미소가 인상적이며 대인관계가 원만합니다.'$1;
+      'mouth': '따뜻한 미소가 인상적이며 대인관계가 원만합니다.',
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- fix unmatched parentheses and commas in physiognomy result page
- remove stray tokens and correct lists
- ensure returned parsing maps use proper syntax

## Testing
- `dart analyze lib/features/fortune/presentation/pages/physiognomy_result_page.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c7ffeef08832fa33f5281a5d30c06