### PR TITLE
Fix purchase restoration and callback type

### DIFF
--- a/fortune_flutter/lib/services/in_app_purchase_service.dart
+++ b/fortune_flutter/lib/services/in_app_purchase_service.dart
@@ -122,9 +122,12 @@ class InAppPurchaseService {
           _purchasePending = true;
           break;
           
-        case PurchaseStatus.purchased: case PurchaseStatus.restore,
-      d:
+        case PurchaseStatus.purchased:
           await _verifyAndDeliverProduct(purchaseDetails);
+          _purchasePending = false;
+          break;
+        case PurchaseStatus.restored:
+          await _handleRestoredPurchase(purchaseDetails);
           _purchasePending = false;
           break;
           
@@ -166,6 +169,11 @@ class InAppPurchaseService {
     } catch (e) {
       debugPrint('Verification error: $e');
     }
+  }
+
+  // Handle restored purchases
+  Future<void> _handleRestoredPurchase(PurchaseDetails purchaseDetails) async {
+    await _verifyAndDeliverProduct(purchaseDetails);
   }
   
   // Restore purchases

--- a/fortune_flutter/lib/services/screenshot_detection_service.dart
+++ b/fortune_flutter/lib/services/screenshot_detection_service.dart
@@ -27,6 +27,7 @@ class ScreenshotDetectionService {
   StreamSubscription<dynamic>? _screenshotSubscription;
   final ScreenshotController _screenshotController = ScreenshotController();
   bool _isListening = false;
+  void Function(BuildContext context)? onScreenshotDialogRequested;
   
   /// Initialize screenshot detection
   Future<void> initialize() async {
@@ -78,7 +79,10 @@ class ScreenshotDetectionService {
   /// Handle screenshot detected event
   void _handleScreenshotDetected(Map<String, dynamic>? data) {
     Logger.info('Screenshot detected');
-    // This will be called by the UI to show dialog
+    // Notify UI through callback if provided
+    if (onScreenshotDialogRequested != null && data?['context'] is BuildContext) {
+      onScreenshotDialogRequested!(data!['context'] as BuildContext);
+    }
   }
   
   /// Show screenshot sharing dialog


### PR DESCRIPTION
## Summary
- handle restored purchases in `InAppPurchaseService`
- add a callback type using `void Function(BuildContext)` in `ScreenshotDetectionService`

## Testing
- `flutter analyze` *(fails: `command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_688c8f6661d4832fbc8e1d7da36fa2b9