### PR TITLE
feat(flags): PR-0c — Exposure logging + 분석 백본

### DIFF
--- a/apps/mobile-rn/src/lib/feature-flag-exposure.ts
+++ b/apps/mobile-rn/src/lib/feature-flag-exposure.ts
@@ -1,0 +1,156 @@
+/**
+ * PR-0c: Feature Flag exposure batch dispatcher.
+ *
+ * 클라 5개 surface 에서 호출 → 메모리 buffer → 10 events 또는 30초마다 flush →
+ * Edge Function POST. 실패는 fail-open (다음 batch 에서 재시도 안 함).
+ *
+ * 사용:
+ * ```ts
+ * await logFlagExposure({
+ *   surface: 'cost_modal',
+ *   flags: { haneul_enabled: true, haneul_fortune_enabled: true, ... },
+ *   versions: { haneul_enabled: 5, ... },
+ *   rampPcts: { haneul_enabled: 100, ... },
+ * });
+ * ```
+ */
+
+import type { FlagId, FlagValue } from '@fortune/product-contracts';
+
+import { appEnv } from './env';
+import { captureError } from './error-reporting';
+import { getInstallId } from './install-id';
+import { supabase } from './supabase';
+
+export type FlagExposureSurface =
+  | 'chat_open'
+  | 'menu_render'
+  | 'cost_modal'
+  | 'generation'
+  | 'route_redirect';
+
+interface BufferedEvent {
+  installId: string;
+  flagName: FlagId;
+  resolvedValue: FlagValue;
+  rampPct: number;
+  configVersion: number;
+  surface: FlagExposureSurface;
+  evaluatedAt: string; // ISO
+}
+
+const BATCH_SIZE = 10;
+const FLUSH_INTERVAL_MS = 30 * 1000;
+const MAX_BUFFER_SIZE = 200; // 방어적 — 폭발 방지
+
+let buffer: BufferedEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleFlush(): void {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    void flushExposureBuffer();
+  }, FLUSH_INTERVAL_MS);
+}
+
+/**
+ * 5개 surface 호출 시점에 호출. 4 flag 모두 한꺼번에 buffer 에 push.
+ */
+export async function logFlagExposure(payload: {
+  surface: FlagExposureSurface;
+  flags: Record<FlagId, FlagValue>;
+  versions: Record<FlagId, number>;
+  rampPcts: Record<FlagId, number>;
+}): Promise<void> {
+  if (!appEnv.isSupabaseConfigured) return;
+
+  let installId: string;
+  try {
+    installId = await getInstallId();
+  } catch {
+    return;
+  }
+
+  const evaluatedAt = new Date().toISOString();
+
+  for (const flagName of Object.keys(payload.flags) as FlagId[]) {
+    if (buffer.length >= MAX_BUFFER_SIZE) {
+      // buffer 폭발 방지 — 가장 오래된 event 제거
+      buffer.shift();
+    }
+    buffer.push({
+      installId,
+      flagName,
+      resolvedValue: payload.flags[flagName],
+      rampPct: payload.rampPcts[flagName] ?? 0,
+      configVersion: payload.versions[flagName] ?? 0,
+      surface: payload.surface,
+      evaluatedAt,
+    });
+  }
+
+  if (buffer.length >= BATCH_SIZE) {
+    void flushExposureBuffer();
+  } else {
+    scheduleFlush();
+  }
+}
+
+/**
+ * 즉시 flush — buffer 비우고 Edge 호출. 호출자가 명시적으로 (e.g. 앱 background 진입 시)
+ * 사용 가능. 실패는 fail-open — buffer 는 비워짐 (분석용 데이터라 손실 acceptable).
+ */
+export async function flushExposureBuffer(): Promise<void> {
+  if (buffer.length === 0) return;
+
+  const events = buffer.slice(0, 100); // max 100 per request
+  buffer = buffer.slice(events.length);
+
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+
+  if (!supabase) return;
+
+  try {
+    const { data: { session } } = await supabase.auth.getSession();
+    const headers: Record<string, string> = {
+      apikey: appEnv.supabaseAnonKey,
+      'Content-Type': 'application/json',
+    };
+    if (session?.access_token) {
+      headers.Authorization = `Bearer ${session.access_token}`;
+    } else {
+      headers.Authorization = `Bearer ${appEnv.supabaseAnonKey}`;
+    }
+
+    await fetch(
+      `${appEnv.supabaseUrl}/functions/v1/feature-flag-exposure-log`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ events }),
+      },
+    );
+    // 응답 무시 — fail-open
+  } catch (err) {
+    captureError(err, { surface: 'feature-flags:exposure-flush' }).catch(() => undefined);
+    // buffer 는 이미 비웠음 — 재시도 X
+  }
+
+  // 남은 buffer 가 있으면 다음 flush 예약
+  if (buffer.length > 0) {
+    scheduleFlush();
+  }
+}
+
+/** 테스트용 — buffer 강제 리셋. */
+export function _resetExposureBufferForTest(): void {
+  buffer = [];
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+}

--- a/apps/mobile-rn/src/lib/feature-flag-exposure.ts
+++ b/apps/mobile-rn/src/lib/feature-flag-exposure.ts
@@ -31,6 +31,10 @@ export type FlagExposureSurface =
 
 interface BufferedEvent {
   installId: string;
+  /** /codex review P2: 이벤트 발생 시점의 userId 를 per-event 캡처. flush 시점의
+   *  auth state 가 다를 수 있어 (anon → 로그인 / 계정 전환) flush 시 일괄 attribution
+   *  하면 잘못된 사용자에게 매핑됨. */
+  userId: string | null;
   flagName: FlagId;
   resolvedValue: FlagValue;
   rampPct: number;
@@ -72,6 +76,18 @@ export async function logFlagExposure(payload: {
     return;
   }
 
+  // /codex review P2: 이벤트 발생 시점의 user_id 캡처. flush 시점에 하면 auth 변경
+  // 시 attribution 깨짐. supabase 클라가 없으면 anon 으로 기록.
+  let userId: string | null = null;
+  if (supabase) {
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      userId = session?.user?.id ?? null;
+    } catch {
+      userId = null;
+    }
+  }
+
   const evaluatedAt = new Date().toISOString();
 
   for (const flagName of Object.keys(payload.flags) as FlagId[]) {
@@ -81,6 +97,7 @@ export async function logFlagExposure(payload: {
     }
     buffer.push({
       installId,
+      userId,
       flagName,
       resolvedValue: payload.flags[flagName],
       rampPct: payload.rampPcts[flagName] ?? 0,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -9,3 +9,6 @@ verify_jwt = false
 # Edge Function 내부에서 Authorization 있으면 userId 추출, 없으면 installId 만으로 sticky ramp.
 [functions.feature-flags-resolve]
 verify_jwt = false
+
+[functions.feature-flag-exposure-log]
+verify_jwt = false

--- a/supabase/functions/feature-flag-exposure-log/index.ts
+++ b/supabase/functions/feature-flag-exposure-log/index.ts
@@ -40,6 +40,9 @@ const ALLOWED_FLAG_NAMES = new Set([
 
 interface ExposureEventInput {
   installId?: string;
+  /** /codex review P2: per-event userId. 클라가 이벤트 발생 시점에 캡처해 보냄.
+   *  flush 시점의 Authorization 보다 정확. anon 이면 null. */
+  userId?: string | null;
   flagName?: string;
   resolvedValue?: unknown;
   rampPct?: number;
@@ -84,13 +87,15 @@ serve(async (req) => {
       auth: { autoRefreshToken: false, persistSession: false },
     });
 
-    // userId 옵션 — auth header 있으면 추출
-    let userId: string | null = null;
+    // /codex review P2: 클라가 per-event userId 를 보냄. flush 시 auth header 있어도
+    // 그 값이 이벤트 발생 시점이라는 보장 없음. 클라 값을 신뢰 (analytics-only,
+    // 보안 결정에 사용 X). auth header 는 검증 / 일관성 체크용으로만 추출.
+    let currentAuthUserId: string | null = null;
     const authHeader = req.headers.get("Authorization");
     if (authHeader) {
       const token = authHeader.replace("Bearer ", "");
       const { data: { user } } = await supabase.auth.getUser(token);
-      userId = user?.id ?? null;
+      currentAuthUserId = user?.id ?? null;
     }
 
     // 입력 검증 + 변환
@@ -113,8 +118,15 @@ serve(async (req) => {
         continue;
       }
 
+      // 클라 per-event userId 신뢰. 추가 안전장치: 클라가 string userId 를 보냈는데
+      // 현재 auth 와 다른 사용자 — 그래도 클라 값 사용 (이벤트 발생 시 정확).
+      // null 또는 undefined 면 fallback 으로 현재 auth user.
+      const eventUserId = typeof ev.userId === "string" && ev.userId.length > 0
+        ? ev.userId
+        : currentAuthUserId;
+
       rows.push({
-        user_id: userId,
+        user_id: eventUserId,
         install_id: ev.installId,
         flag_name: ev.flagName,
         resolved_value: ev.resolvedValue,

--- a/supabase/functions/feature-flag-exposure-log/index.ts
+++ b/supabase/functions/feature-flag-exposure-log/index.ts
@@ -1,0 +1,162 @@
+// PR-0c: Feature Flag exposure batch insert.
+//
+// POST /feature-flag-exposure-log
+// Body: { events: ExposureEvent[] }
+//
+// ExposureEvent:
+//   { installId, userId? (Authorization header 에서 추출되면 우선), flagName,
+//     resolvedValue, rampPct, configVersion, surface, evaluatedAt }
+//
+// - 한 요청에 max 100 events
+// - service_role 로 직접 INSERT (RLS bypass)
+// - 실패는 fail-open — 클라가 다음 batch 에서 재시도하지 않음 (분석용 데이터라
+//   완벽 도착 보장 불필요)
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const MAX_EVENTS_PER_REQUEST = 100;
+
+const ALLOWED_SURFACES = new Set([
+  "chat_open",
+  "menu_render",
+  "cost_modal",
+  "generation",
+  "route_redirect",
+]);
+
+const ALLOWED_FLAG_NAMES = new Set([
+  "haneul_enabled",
+  "haneul_fortune_enabled",
+  "direct_chips_enabled",
+  "fortune_route_behavior",
+]);
+
+interface ExposureEventInput {
+  installId?: string;
+  flagName?: string;
+  resolvedValue?: unknown;
+  rampPct?: number;
+  configVersion?: number;
+  surface?: string;
+  evaluatedAt?: string; // ISO
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const { events } = body as { events?: ExposureEventInput[] };
+
+    if (!Array.isArray(events) || events.length === 0) {
+      return new Response(
+        JSON.stringify({ error: "Missing events" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    if (events.length > MAX_EVENTS_PER_REQUEST) {
+      return new Response(
+        JSON.stringify({ error: `Too many events (max ${MAX_EVENTS_PER_REQUEST})` }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // userId 옵션 — auth header 있으면 추출
+    let userId: string | null = null;
+    const authHeader = req.headers.get("Authorization");
+    if (authHeader) {
+      const token = authHeader.replace("Bearer ", "");
+      const { data: { user } } = await supabase.auth.getUser(token);
+      userId = user?.id ?? null;
+    }
+
+    // 입력 검증 + 변환
+    const rows = [];
+    let invalid = 0;
+    const nowIso = new Date().toISOString();
+    for (const ev of events) {
+      if (
+        !ev.installId ||
+        typeof ev.installId !== "string" ||
+        !ev.flagName ||
+        typeof ev.flagName !== "string" ||
+        !ALLOWED_FLAG_NAMES.has(ev.flagName) ||
+        ev.surface == null ||
+        typeof ev.surface !== "string" ||
+        !ALLOWED_SURFACES.has(ev.surface) ||
+        ev.resolvedValue === undefined
+      ) {
+        invalid++;
+        continue;
+      }
+
+      rows.push({
+        user_id: userId,
+        install_id: ev.installId,
+        flag_name: ev.flagName,
+        resolved_value: ev.resolvedValue,
+        ramp_pct: typeof ev.rampPct === "number" ? Math.max(0, Math.min(100, Math.floor(ev.rampPct))) : 0,
+        config_version: typeof ev.configVersion === "number" && Number.isFinite(ev.configVersion)
+          ? Math.floor(ev.configVersion)
+          : 0,
+        surface: ev.surface,
+        evaluated_at: ev.evaluatedAt && typeof ev.evaluatedAt === "string"
+          ? ev.evaluatedAt
+          : nowIso,
+      });
+    }
+
+    if (rows.length === 0) {
+      return new Response(
+        JSON.stringify({ inserted: 0, invalid }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    const { error } = await supabase
+      .from("feature_flag_exposures")
+      .insert(rows);
+
+    if (error) {
+      console.error("[feature-flag-exposure-log] insert 실패:", error.message);
+      return new Response(
+        JSON.stringify({ error: "Insert failed" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ inserted: rows.length, invalid }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  } catch (err) {
+    console.error("[feature-flag-exposure-log] error:", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+});

--- a/supabase/migrations/20260506200000_feature_flag_exposures.sql
+++ b/supabase/migrations/20260506200000_feature_flag_exposures.sql
@@ -1,0 +1,66 @@
+-- PR-0c: Feature Flag exposure logging — 어느 사용자/install 이 어떤 surface 에서
+-- 어떤 flag 값을 받았는지 기록. ramp 의사결정 / 사용자 컴플레인 디버깅 / 안전성
+-- 검증의 기반.
+--
+-- 디자인:
+-- - 5개 surface 에서 발행: chat_open / menu_render / cost_modal / generation /
+--   route_redirect
+-- - flag 별 4 row (4 flag) 가 한 surface 호출 시 발행 — 평균적으로 표 row 가 빠르게 쌓임
+-- - 운영: 30일 보존 정책 (별도 cron). 본 PR 은 보존 자체는 강제 안 함
+-- - 개인정보: user_id (Supabase UUID 그대로) + install_id. 운세 컨텐츠/대화 X
+-- - 인덱스: 사용자별 trace, flag 별 ramp 분석 양쪽 지원
+
+CREATE TABLE IF NOT EXISTS feature_flag_exposures (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID,
+  install_id TEXT NOT NULL,
+  flag_name VARCHAR(50) NOT NULL,
+  resolved_value JSONB NOT NULL,
+  ramp_pct INTEGER NOT NULL,
+  config_version BIGINT NOT NULL,
+  surface VARCHAR(50) NOT NULL,
+  evaluated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- 클라이언트 batch buffer 가 도착한 시각 (서버 receipt time)
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE feature_flag_exposures IS
+  'PR-0c: feature flag exposure log. ramp 분석 + 사용자 컴플레인 디버깅용.';
+COMMENT ON COLUMN feature_flag_exposures.user_id IS
+  '로그인 사용자 — Supabase auth.users.id. anon 사용자는 NULL.';
+COMMENT ON COLUMN feature_flag_exposures.install_id IS
+  '클라 디바이스 단위 ID — anon 사용자도 sticky bucket 추적 가능.';
+COMMENT ON COLUMN feature_flag_exposures.surface IS
+  'flag 평가 surface: chat_open | menu_render | cost_modal | generation | route_redirect.';
+COMMENT ON COLUMN feature_flag_exposures.evaluated_at IS
+  '클라/Edge 가 flag 평가한 시각. 디바이스 시계 기준이라 부정확 가능.';
+COMMENT ON COLUMN feature_flag_exposures.ingested_at IS
+  '서버 INSERT 시각. 정확한 시간 분석에 사용.';
+
+-- 사용자/install 별 trace — 컴플레인 디버깅 ("나 하늘이 안 보임")
+CREATE INDEX IF NOT EXISTS idx_feature_flag_exposures_user_flag_time
+  ON feature_flag_exposures (user_id, flag_name, evaluated_at DESC)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_feature_flag_exposures_install_flag_time
+  ON feature_flag_exposures (install_id, flag_name, evaluated_at DESC);
+
+-- flag 별 ramp 분석 — 시간대별 노출 rate
+CREATE INDEX IF NOT EXISTS idx_feature_flag_exposures_flag_time
+  ON feature_flag_exposures (flag_name, evaluated_at DESC);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- RLS — service_role 만 INSERT/SELECT. 클라/anon 직접 접근 차단.
+-- (analytics 데이터에 접근하려면 Edge Function 거쳐야)
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE feature_flag_exposures ENABLE ROW LEVEL SECURITY;
+
+-- 명시적 정책 안 만들면 anon/authenticated 는 SELECT/INSERT 모두 거부 (RLS 기본)
+
+GRANT SELECT, INSERT ON feature_flag_exposures TO service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 보존 정책 — 별도 cron 으로 처리. 본 마이그레이션에서는 가이드만 주석으로.
+-- ─────────────────────────────────────────────────────────────────────────────
+-- DELETE FROM feature_flag_exposures WHERE ingested_at < NOW() - INTERVAL '30 days';
+-- 운영: 일일 cron 으로 30일 이전 row 삭제. 분석은 30일 윈도우에 충분.


### PR DESCRIPTION
## Summary

PR-0a (결제) → PR-0b (flag) 위에 분석 파이프라인 첫 도입. 5개 surface 에서 flag 평가 시 batch 로 buffered → Edge POST → DB insert. ramp 의사결정 + 사용자 컴플레인 디버깅 + 안전성 검증의 기반.

**Stacked PR**: PR-0b (#201) 이 base. PR-0b 머지 후 base 가 master 로 자동 변경.

## 주요 변경

**DB 마이그레이션**
- \`feature_flag_exposures\` 테이블 (user_id + install_id + flag_name + resolved_value + ramp_pct + config_version + surface + evaluated_at + ingested_at)
- 인덱스 3개: 사용자/install 별 trace + flag 별 ramp 분석
- RLS: service_role 전용 — 클라/anon 직접 접근 차단
- 30일 보존 정책은 별도 cron (본 PR 은 가이드만)

**Edge Function**
- \`feature-flag-exposure-log\`: batch insert (max 100/req). flag_name/surface allowlist 검증. fail-open
- per-event userId 신뢰 (codex P2 수정 — flush 시점 attribution 버그)

**클라**
- \`feature-flag-exposure.ts\`: 메모리 buffer 10 events 또는 30초마다 flush. 폭발 방지 max 200. 실패 시 buffer 비움 (재시도 X — 분석용)
- per-event userId 캡처 (codex P2)
- 5 surface API 만 — 실제 surface 호출은 PR-B/C 에서 wired up (의도적 deferral)

## 개인정보

- user_id (Supabase auth UUID 그대로) + install_id
- 운세 컨텐츠/대화/이름/생년월일 등 절대 미저장
- RLS 로 분석 테이블 접근 service_role 만

## 검증

- ✅ \`npx tsc --noEmit\` (RN)
- ✅ \`deno check\` (Edge Function)
- ✅ \`/codex review\` 1회 — P2 (auth context 잘못 attribution) 발견 후 hotfix 커밋

## Test plan

- [ ] \`supabase db push --include-all\`
- [ ] \`supabase functions deploy feature-flag-exposure-log\`
- [ ] 클라 \`logFlagExposure({ surface: 'chat_open', ... })\` 호출 → 30초 후 또는 10 events 후 flush → DB row 확인
- [ ] anon → 로그인 시나리오: 이벤트 anon 으로 발행 → 로그인 → flush → user_id 가 null 인 row 확인 (per-event 캡처 정상)
- [ ] 100 events 한 번에 flush → DB rows 100개
- [ ] 잘못된 flag_name 또는 surface 보냄 → 400 또는 invalid 카운트
- [ ] 네트워크 단절 시 buffer 비움 (재시도 안 함, 분석용 데이터라 acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)