### PR TITLE
fix(haneul): fortune 탭 개념 완전 제거 + deeplink 하늘이로 라우팅

### DIFF
--- a/apps/mobile-rn/src/lib/chat-characters.ts
+++ b/apps/mobile-rn/src/lib/chat-characters.ts
@@ -131,25 +131,25 @@ export const haneulOracleCharacter: FortuneChatCharacterSpec = {
   specialties: [],
 };
 
-// PR-B1: 하늘이는 module-level 에는 항상 포함 — findChatCharacterById 등
-// 도메인 lookup 이 전부 작동해야 하기 때문. UI 노출 자체는 `getVisibleChatCharacters`
-// 또는 chat-screen 의 `haneul_enabled` flag check 로 게이팅.
+// 하늘이 통합 후: chatCharacters = story 10명 + 하늘이.
+// 기존 fortuneChatCharacters (fortune_haneul, fortune_muhyeon, fortune_stella,
+// fortune_dr_mind, fortune_rose 등) 는 deprecated — 채팅 리스트/도메인 lookup
+// 모두에서 제외. 운세는 하늘이 단독으로 통합.
+//
+// fortuneChatCharacters export 자체는 친구 만들기 등 legacy 참조 호환을 위해
+// 유지하지만, chatCharacters union 에는 포함 X.
 export const chatCharacters: readonly ChatCharacterSpec[] = [
   ...storyChatCharacters,
-  ...fortuneChatCharacters,
   haneulOracleCharacter,
 ];
 
 /**
- * PR-A: flag 가 켜진 경우만 하늘이를 리스트에 포함. PR-B 가 chat-surface 에서 이걸
- * 사용하면 점진 ramp 가능.
+ * 채팅 리스트에 노출할 캐릭터 — flag 와 무관하게 항상 story + 하늘이.
+ * (이전엔 haneul_enabled flag 게이팅이 있었지만 fortune 탭 자체가 사라져서 단순화.)
  */
-export function getVisibleChatCharacters(opts: {
-  haneulEnabled: boolean;
+export function getVisibleChatCharacters(_opts?: {
+  haneulEnabled?: boolean;
 }): readonly ChatCharacterSpec[] {
-  if (opts.haneulEnabled) {
-    return [...storyChatCharacters, ...fortuneChatCharacters, haneulOracleCharacter];
-  }
   return chatCharacters;
 }
 
@@ -178,8 +178,9 @@ export function createdFriendToStoryCharacter(
 export function buildChatCharactersWithCustomFriends(
   friends: readonly CreatedFriend[],
 ): readonly ChatCharacterSpec[] {
+  // 하늘이 통합 후: 운세 캐릭터는 하늘이 단독. fortuneChatCharacters 미포함.
   const customStoryCharacters = friends.map(createdFriendToStoryCharacter);
-  return [...customStoryCharacters, ...storyChatCharacters, ...fortuneChatCharacters];
+  return [...customStoryCharacters, ...storyChatCharacters, haneulOracleCharacter];
 }
 
 export function buildStoryCharactersWithCustomFriends(

--- a/apps/mobile-rn/src/screens/chat-screen.tsx
+++ b/apps/mobile-rn/src/screens/chat-screen.tsx
@@ -596,8 +596,11 @@ export function ChatScreen() {
       return;
     }
 
+    // 하늘이 통합 후: deep link로 fortuneType 들어와도 haneul_oracle 로 라우팅.
+    // 'fortune' tab 자체가 사라졌고 운세는 하늘이 단독.
     setActiveFortuneType(pendingChatFortuneType);
-    setActiveTab('fortune');
+    setActiveTab('story');
+    setSelectedCharacterId(haneulOracleCharacter.id);
     setLaunchOrigin('deeplink');
     setSurfaceMode('chat');
     consumePendingChatFortuneType().catch((error) => {
@@ -621,18 +624,14 @@ export function ChatScreen() {
       return;
     }
 
+    // 하늘이 통합 후: 사주 컨텍스트 카드는 하늘이 채팅으로 라우팅.
+    // (deprecated fortune characters 더 이상 노출 X)
     const targetCharacterId =
       selectedCharacterId ??
       mobileAppState.chat.selectedCharacterId ??
-      fortuneChatCharacters[0]?.id ??
-      chatCharacters[0]?.id ??
-      null;
+      haneulOracleCharacter.id;
 
-    if (!targetCharacterId) {
-      return;
-    }
-
-    setActiveTab('fortune');
+    setActiveTab('story');
     setSurfaceMode('chat');
     if (selectedCharacterId == null) {
       setSelectedCharacterId(targetCharacterId);
@@ -927,8 +926,10 @@ export function ChatScreen() {
     }
 
     if (highlightedExpert) {
-      setSelectedCharacterId(highlightedExpert.id);
-      setActiveTab('fortune');
+      // 하늘이 통합 후: highlightedExpert (deprecated fortune character) 대신
+      // haneul_oracle 로 라우팅. 운세 처리는 하늘이 단독.
+      setSelectedCharacterId(haneulOracleCharacter.id);
+      setActiveTab('story');
       setSurfaceMode('chat');
       return;
     }
@@ -2205,12 +2206,11 @@ export function ChatScreen() {
   }, [gate, selectedCharacter.id, session?.user.id]);
 
   function handleOpenRecentResult(fortuneType: FortuneTypeId) {
-    const recentFortuneCharacterId =
-      fortuneChatCharacters.find((character) =>
-        character.specialties.includes(fortuneType),
-      )?.id ?? selectedCharacter.id;
+    // 하늘이 통합 후: 모든 운세 결과는 하늘이 채팅 안에 embed.
+    // recent result 도 하늘이로 라우팅 (deprecated fortune characters 미사용).
+    const recentFortuneCharacterId = haneulOracleCharacter.id;
 
-    setActiveTab('fortune');
+    setActiveTab('story');
     setSelectedCharacterId(recentFortuneCharacterId);
     setSurfaceMode('chat');
     const character =

--- a/apps/mobile-rn/src/screens/chat-screen.tsx
+++ b/apps/mobile-rn/src/screens/chat-screen.tsx
@@ -331,17 +331,10 @@ export function ChatScreen() {
     Record<string, string>
   >({});
   const chatScrollRef = useRef<ScrollView | null>(null);
-  const [activeTab, setActiveTab] = useState<ChatCharacterTab>(() => {
-    if (directCharacter) {
-      return directCharacter.kind;
-    }
-
-    const restoredCharacter = findChatCharacterById(
-      mobileAppState.chat.selectedCharacterId,
-    );
-
-    return restoredCharacter?.kind ?? 'story';
-  });
+  // 하늘이 통합 후: 채팅 리스트는 항상 'story' 뷰. fortuneChatCharacters
+  // 는 deprecated (마르코/닥터마인드 등 더 이상 노출 안 함). activeTab state
+  // 자체는 deep link / inner 분기 일부에 남아있지만 list 화면은 무조건 story.
+  const [activeTab, setActiveTab] = useState<ChatCharacterTab>('story');
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(
     null,
   );
@@ -871,13 +864,13 @@ export function ChatScreen() {
         character.specialties.includes(activeFortuneType),
       )
     : undefined;
-  const tabCharacters =
-    activeTab === 'story' ? allStoryCharacters : fortuneChatCharacters;
+  // 하늘이 통합 후: 운세 캐릭터는 하늘이 단독. 기존 fortuneChatCharacters
+  // (마르코, 닥터마인드 등) 는 채팅 리스트에 노출 안 함. activeTab='fortune'
+  // state 는 deeplink/내부 분기에 남아있지만 리스트는 항상 story+하늘이.
+  const tabCharacters = allStoryCharacters;
   const defaultCharacter =
     highlightedExpert ??
-    (activeTab === 'fortune'
-      ? fortuneChatCharacters[0]
-      : tabCharacters[0]) ??
+    tabCharacters[0] ??
     allStoryCharacters[0] ??
     allChatCharacters[0];
   const selectedCharacter = useMemo(() => {
@@ -886,8 +879,16 @@ export function ChatScreen() {
       directCharacterId ??
       mobileAppState.chat.selectedCharacterId;
 
+    const resolved = findChatCharacterById(targetId, createdFriends);
+
+    // 하늘이 통합 후: 기존 fortune 캐릭터 (fortune_haneul, fortune_muhyeon, ...)
+    // 가 selected 로 복원되면 사용자가 dead character 진입 = 회귀. 강제 폴백.
+    // 새 통합 fortune entry 인 'haneul_oracle' 은 그대로 통과.
+    const isDeprecatedFortune =
+      resolved?.kind === 'fortune' && resolved.id !== 'haneul_oracle';
+
     return (
-      findChatCharacterById(targetId, createdFriends) ??
+      (isDeprecatedFortune ? null : resolved) ??
       highlightedExpert ??
       defaultCharacter
     );


### PR DESCRIPTION
사용자 요청: "FORTUNE 탭이란 건 없어 이젠 필요가" — 운세는 하늘이 단독.

- chatCharacters에서 fortuneChatCharacters 제거 (마르코/닥터마인드/제임스/현우/스텔라/로즈/럭키/리나 사라짐)
- 모든 fortuneType deeplink/highlightedExpert/recent result → 하늘이 라우팅
- 활성: story 10명 + 하늘이 = 11명