### PR TITLE
fix: allowlist gitleaks false positives breaking Security Scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,6 +11,7 @@ paths = [
     '''(^|/)supabase/\.temp/''',
     '''(^|/)docs/getting-started/''',
     '''(^|/)docs/testing/''',
+    '''(^|/)scripts/design/paper_sync_guard\.js$''',
 ]
 regexes = [
     '''process\.env\.[A-Z0-9_]+''',
@@ -19,6 +20,8 @@ regexes = [
     '''com\.beyond\.fortune\.tokens\d+''',
     '''token_bonus_rate|token_packages|popular_token_package|daily_free_tokens|referral_bonus_tokens|new_user_bonus_tokens''',
     '''/api/(user|payment|admin)/token''',
+    '''fortune\.push\.pending-token''',
+    '''your-service-role-key''',
 ]
 commits = [
     "ab66de62b3babf31717fe8914e346b85b6871843",


### PR DESCRIPTION
## Summary

The **Security Scan** workflow has been failing since June 24 (run #893) due to 3 false positive findings from Gitleaks. This PR adds allowlist entries to `.gitleaks.toml` to suppress them:

| Finding | File | Why it's a false positive |
|---------|------|--------------------------|
| `generic-secret` | `push-notifications.ts:17` | `PENDING_PUSH_TOKEN_KEY = 'fortune.push.pending-token.v1'` — a SecureStore key name, not a secret |
| `generic-secret` | `scripts/design/paper_sync_guard.js:13` | Deleted file still in git history; `tokensPath` was a file path |
| `supabase-service-role-key` | `upload_images_to_supabase.sh:27` | `echo "export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key"` — placeholder help text |

### Changes
- Added `fortune\.push\.pending-token` and `your-service-role-key` to regex allowlist
- Added `scripts/design/paper_sync_guard.js` to path allowlist

## Test plan
- [ ] Merge and verify Security Scan workflow passes on next scheduled run
- [ ] No real secrets are being suppressed (all 3 are confirmed non-secrets)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtWKey3fb2HmmDEShYHmHu)_