### PR TITLE
fix: allowlist gitleaks false-positive fingerprints

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,6 +23,11 @@ regexes = [
 commits = [
     "ab66de62b3babf31717fe8914e346b85b6871843",
 ]
+fingerprints = [
+    "d84207d6cca3043efe8973028604bcd37ecdf6ba:apps/mobile-rn/src/lib/push-notifications.ts:generic-secret:17",
+    "d84207d6cca3043efe8973028604bcd37ecdf6ba:scripts/design/paper_sync_guard.js:generic-secret:13",
+    "d84207d6cca3043efe8973028604bcd37ecdf6ba:scripts/upload_images_to_supabase.sh:supabase-service-role-key:27",
+]
 
 [[rules]]
 id = "firebase-api-key"


### PR DESCRIPTION
## Summary

The **Security Scan** workflow has been failing daily for **9+ consecutive days** because gitleaks detects 3 false positives from commit `d84207d6`:

| File | Rule | Why it's a false positive |
|------|------|--------------------------|
| `push-notifications.ts:17` | `generic-secret` | `PENDING_PUSH_TOKEN_KEY = 'fortune.push.pending-token.v1'` — SecureStore key **name**, not a secret value |
| `paper_sync_guard.js:13` | `generic-secret` | Deleted file; path constant containing "tokens" |
| `upload_images_to_supabase.sh:27` | `supabase-service-role-key` | `echo "export SUPABASE_SERVICE_ROLE_KEY=your-service-role-key"` — **placeholder** help text |

### Fix

Adds a `fingerprints` array to `.gitleaks.toml` with the exact fingerprint for each finding. This is gitleaks' recommended mechanism for suppressing specific false positives without weakening the scan for real secrets.

Previous fix attempts (branches `fix/gitleaks-false-positives` and `fix/gitleaks-false-positives-v2`) did not add fingerprint entries, which is why the scan kept failing.

## Test plan

- [ ] Security Scan workflow passes on next scheduled run (daily at 2 AM UTC)
- [ ] Verify no real secrets are inadvertently allowlisted (fingerprints are commit+file+rule+line specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQGCoRAdy4sbpZuU1rZc2

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsQGCoRAdy4sbpZuU1rZc2)_