### PR TITLE
[NO-JIRA] fix: move skip-link focus to main content

### DIFF
--- a/playwright/tests/ondo-public-site.spec.js
+++ b/playwright/tests/ondo-public-site.spec.js
@@ -183,6 +183,9 @@ test.describe('keyboard access', () => {
     expect(skipLinkOutline.style).not.toBe('none');
     expect(skipLinkOutline.width).toBeGreaterThan(0);
 
+    await page.keyboard.press('Enter');
+    await expect(page.locator('main#main')).toBeFocused();
+
     let reachedPrivacyLink = false;
     for (let index = 0; index < 15; index += 1) {
       await page.keyboard.press('Tab');

--- a/public/404.html
+++ b/public/404.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="eyebrow">404</div>
       <h1>페이지를 찾을 수 없습니다</h1>
       <p class="muted">

--- a/public/delete-account.html
+++ b/public/delete-account.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="eyebrow">Account Deletion</div>
       <h1>Ondo 계정 삭제 안내</h1>
       <p class="muted">

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="meta">
         <span>Store Review</span>
         <span>Support</span>

--- a/public/open-in-app.html
+++ b/public/open-in-app.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="eyebrow">App Only</div>
       <h1>이 화면은 Ondo 앱에서 열립니다</h1>
       <p class="muted" data-testid="native-route-notice">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="eyebrow">Privacy Policy</div>
       <h1>Ondo 개인정보처리방침</h1>
       <p class="muted">

--- a/public/support.html
+++ b/public/support.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="eyebrow">Support</div>
       <h1>Ondo 고객 지원</h1>
       <p class="muted">

--- a/public/terms.html
+++ b/public/terms.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
-    <main id="main">
+    <main id="main" tabindex="-1">
       <div class="eyebrow">Terms of Service</div>
       <h1>Ondo 이용약관</h1>
       <p class="muted">

--- a/scripts/validate-ondo-web-readiness.mjs
+++ b/scripts/validate-ondo-web-readiness.mjs
@@ -308,6 +308,10 @@ export function assertPublicAssets(runner) {
     runner.check(`${name} has a non-empty title`, /<title>[^<]+<\/title>/.test(html));
     runner.check(`${name} has a meta description`, /<meta\s+name="description"/.test(html));
     runner.check(`${name} has exactly one main landmark`, (html.match(/<main[\s>]/g) ?? []).length === 1);
+    runner.check(
+      `${name} makes the skip-link target programmatically focusable`,
+      /<main\b(?=[^>]*\bid="main")(?=[^>]*\btabindex="-1")[^>]*>/.test(html),
+    );
     runner.check(`${name} has exactly one h1`, (html.match(/<h1[\s>]/g) ?? []).length === 1);
     runner.check(`${name} references the shared stylesheet`, html.includes('/assets/site.css'));
     runner.check(`${name} references /favicon.ico`, html.includes('/favicon.ico'));


### PR DESCRIPTION
## Summary
- make every public page main landmark programmatically focusable
- verify skip-link Enter transfers focus to the main content
- enforce the focus target contract in the static readiness validator

## Verification
- `npm run web:validate` — 276/276
- Playwright public-site suite — 43/43
- axe WCAG A/AA — 33 route/viewport checks, 0 violations
- W3C Nu — 7/7 pages, 0 errors / 0 warnings
- edge pricing sync, mobile-rn typecheck, Supabase RLS audit — pass