### PR TITLE
[NO-JIRA] 온도 웹 정적 CSP 회귀 방지

### DIFF
--- a/playwright/tests/web/daily.spec.ts
+++ b/playwright/tests/web/daily.spec.ts
@@ -36,6 +36,14 @@ test.describe('랜딩 페이지', () => {
     expect(body).toContain('Disallow: /api/');
   });
 
+  test('웹 CSP가 React client script를 차단하지 않는다', async ({ request }) => {
+    const response = await request.get('/auth/login');
+    expect(response.ok()).toBeTruthy();
+
+    const csp = response.headers()['content-security-policy'] ?? '';
+    expect(csp).not.toContain("script-src 'none'");
+  });
+
   test('푸터가 운영 정책과 고객지원 문서를 연결한다', async ({ page }) => {
     await page.goto('/');
 


### PR DESCRIPTION
## 문제
- ondo-web Vercel Root Directory가 저장소 루트로 설정되어 정적 정책 사이트용 `script-src 'none'` CSP가 Next.js 앱에 적용됨\n- React hydration과 Google 로그인 버튼 동작이 차단됨\n\n## 수정\n- Vercel `ondo-web` Root Directory를 `apps/web`으로 교정\n- `/auth/login` CSP가 client script를 차단하지 않는 Playwright 회귀 테스트 추가\n\n## 검증\n- RED: 현재 잘못된 production CSP에서 새 테스트 실패\n- GREEN: 로컬 production build + 새 테스트 통과\n- web typecheck 통과\n- Next.js build 56 routes 통과\n- 웹 스모크 6 passed / 1 deployment-only skipped\n- Vercel preview READY: `https://ondo-1ccf5txdl-injooinjoos-projects.vercel.app`\n- preview `/auth/login`: HTTP 200, CSP 없음, Next.js script 10개, Google 버튼 렌더링