### PR TITLE
docs: default iOS releases to local Xcode

### DIFF
--- a/APP_STORE_REVIEW_NOTE.md
+++ b/APP_STORE_REVIEW_NOTE.md
@@ -7,7 +7,7 @@
 - **Primary path:** guest-first review path.
 - **App Store Connect Sign-in required:** `NO`.
 - **Optional test account:** provide for account-gated flows such as profile sync, purchase verification, purchase restore, subscription/token balance sync, and account deletion.
-- **Current release decision:** `NO-GO` until clean frozen SHA, fresh EAS iOS production build, and required iPhone/iPad/IAP evidence are captured.
+- **Current release decision:** `NO-GO` until a clean frozen SHA is archived locally in Xcode, the exact archive is uploaded and processed in App Store Connect/TestFlight, and required iPhone/iPad/IAP evidence is captured.
 
 ## Review notes to paste into App Store Connect
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,9 @@ Stop 훅 `scripts/auto-deploy-on-stop.sh`은 **리뷰 모드가 디폴트**입�
 
 실제 배포 명령(사용자 직접 실행 또는 사용자 명시 승인 후 Claude 실행):
 - Edge Function: `supabase functions deploy <fn>`
-- RN OTA: `cd apps/mobile-rn && eas update --branch production`
-- Native 변경: `pnpm deploy:native` (EAS build)
+- iOS 바이너리: `pnpm rn:native:prepare` → `pnpm rn:ios:xcode` → Xcode **Product → Archive** → Organizer **App Store Connect → Upload**
+- TestFlight 확인: App Store Connect에서 exact version/build 처리 완료 확인 후 실기기 설치·스모크
+- EAS OTA/Cloud Build: 기본 경로 아님. 사용자가 해당 작업과 비용/배포를 명시 승인한 경우에만 실행
 - DB 마이그레이션: `supabase db push --include-all`
 
 `/ship`은 CHANGELOG + commit + PR까지만 — 실제 배포는 머지 후 또는 위 명령으로.
@@ -132,7 +133,8 @@ Stop 훅 `scripts/auto-deploy-on-stop.sh`은 **리뷰 모드가 디폴트**입�
 
 | 금지 | 이유 | 대안 |
 |------|------|------|
-| `expo start` / `eas build` 직접 실행 | 로그 확인 불가, 대화형 프롬프트 | 사용자에게 실행 요청 |
+| `expo start` 직접 실행 | 장기 실행 프로세스·대화형 로그 | 사용자에게 수동 실행 요청 |
+| `eas build` / `deploy:native` / `deploy:ota` | 유료 클라우드 빌드 또는 원격 배포가 기본 경로로 오인됨 | 로컬 Xcode Archive→TestFlight; EAS는 해당 작업의 명시 승인 때만 |
 | 일괄 수정 (`for`, `sed -i`) | 프로젝트 망가짐 | 한 파일씩 Edit |
 | `any` 타입 남발 | 타입 안전성 파괴 | 정확한 타입 정의 또는 `unknown` |
 | 하드코딩 색상/폰트 | 디자인 시스템 위반 | `fortuneTheme.colors.*`, `AppText variant` |

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ Do not start Expo or Metro from automation. For manual app testing, run the RN s
 - [Project overview](docs/getting-started/PROJECT_OVERVIEW.md)
 - [Architecture](docs/APP_ARCHITECTURE.md)
 - [Local native iOS testing](docs/development/local-native-ios-testing.md)
-- [Expo CNG build and release](docs/development/expo-cng-build-and-release.md)
+- [Expo CNG local build and TestFlight release](docs/development/expo-cng-build-and-release.md)
 
 ## Security
 
 - Keep secrets out of git.
 - Use `.env.example` only for placeholder documentation.
-- Runtime secrets are provided through local env files, EAS secrets, Supabase secrets, or GitHub Actions secrets depending on the boundary.
+- Runtime secrets are provided through local env files, Supabase secrets, or GitHub Actions secrets depending on the boundary. EAS secrets are legacy/emergency-only and apply only to an explicitly approved EAS operation.

--- a/artifacts/ios-review-fixes/asc/04-build-deploy-guide.md
+++ b/artifacts/ios-review-fixes/asc/04-build-deploy-guide.md
@@ -1,6 +1,6 @@
 # iOS 빌드 + 제출 가이드
 
-커밋 완료 후 실제 빌드·제출까지의 명령 순서. 사용자가 터미널에서 직접 실행해야 합니다 (Claude는 `expo start`/`eas build` 직접 실행 금지).
+커밋 완료 후 실제 빌드·제출까지의 순서. 현재 기본 경로는 **로컬 Xcode Archive → App Store Connect/TestFlight**이며 EAS Cloud Build를 사용하지 않습니다. 최신 정책은 `docs/development/expo-cng-build-and-release.md`가 우선합니다.
 
 ---
 
@@ -9,18 +9,15 @@
 ```bash
 cd /Users/injoo/Desktop/Dev/fortune/apps/mobile-rn
 
-# 1. 환경 변수 — SUPABASE_URL, SUPABASE_ANON_KEY, OPENAI_API_KEY 등이 EAS
-#    secret에 올바르게 등록돼 있는지 확인.
-npx eas secret:list
+# 1. 로컬 release 환경에 필요한 EXPO_PUBLIC_* 값이 준비됐는지 이름만 확인.
+#    비밀 값 자체는 출력하거나 문서/로그에 남기지 않는다.
 
-# 2. Apple Developer 인증서/프로비저닝 프로파일
-npx eas credentials --platform ios
+# 2. Xcode Settings > Accounts에서 Apple Developer 계정/Team이 활성인지 확인.
 
-# 3. ASC App ID 일치 확인 (eas.json: 6749496180)
-cat eas.json | grep ascAppId
+# 3. App Store Connect 앱의 bundle ID가 com.beyond.fortune인지 확인.
 ```
 
-필요한 EAS secrets (누락 시 설정):
+필요한 로컬 release 환경 변수(값은 안전한 로컬 환경에서만 제공):
 - `EXPO_PUBLIC_SUPABASE_URL`
 - `EXPO_PUBLIC_SUPABASE_ANON_KEY`
 - `EXPO_PUBLIC_SENTRY_DSN`
@@ -36,15 +33,17 @@ cat eas.json | grep ascAppId
 ```bash
 cd /Users/injoo/Desktop/Dev/fortune/apps/mobile-rn
 
-# 기존 ios/ + android/ 완전 삭제 후 재생성
-npx expo prebuild --clean --platform ios
+# ios/ 재생성, CocoaPods 설치, workspace/scheme 확인
+cd /Users/injoo/Desktop/Dev/fortune
+pnpm rn:native:prepare
+pnpm rn:native:doctor
 
 # 검증 — 생성된 Info.plist에 실제로 반영됐는지 확인
-grep -A1 "CFBundleShortVersionString" ios/app/Info.plist   # → 1.0.9
-grep -A1 "UIUserInterfaceStyle" ios/app/Info.plist          # → Dark
-grep -c "com.beyond.fortune" ios/app/Info.plist             # → 1 (중복 없음)
-grep -A1 "NSSpeechRecognitionUsageDescription" ios/app/Info.plist  # → 한국어 문구
-grep "NSPrivacyCollectedDataType" ios/app/PrivacyInfo.xcprivacy | wc -l  # → 11
+plutil -p apps/mobile-rn/ios/app/Info.plist | grep CFBundleShortVersionString
+plutil -p apps/mobile-rn/ios/app/Info.plist | grep UIUserInterfaceStyle   # → Dark
+grep -c "com.beyond.fortune" apps/mobile-rn/ios/app/Info.plist          # → 1 (중복 없음)
+plutil -p apps/mobile-rn/ios/app/Info.plist | grep NSSpeechRecognitionUsageDescription
+grep "NSPrivacyCollectedDataType" apps/mobile-rn/ios/app/PrivacyInfo.xcprivacy | wc -l  # → 11
 ```
 
 **위 검증 모두 통과해야 다음 단계 진행.** 하나라도 다르면 `app.config.ts` 설정이 반영 안 된 것.
@@ -123,11 +122,11 @@ curl -i -X POST "https://<PROJECT_REF>.supabase.co/functions/v1/widget-cache" \
 
 ## 3. iOS 빌드 + 제출
 
-### 3a. 로컬 확인용 (옵션 — 시뮬레이터 QA)
+### 3a. 로컬 확인용 (시뮬레이터 QA)
 
 ```bash
-cd /Users/injoo/Desktop/Dev/fortune/apps/mobile-rn
-npx expo run:ios --device
+cd /Users/injoo/Desktop/Dev/fortune
+pnpm rn:native:build
 # 시뮬레이터에서 다음 시나리오 수동 확인:
 #   - welcome carousel (신규 설치) → 한 번만 뜸
 #   - test@zpzg.com 로그인 → chat 진입 (welcome 건너뜀)
@@ -137,28 +136,34 @@ npx expo run:ios --device
 #   - 다크모드 고정 확인 (시스템 라이트 모드에서도 앱은 다크)
 ```
 
-### 3b. Production 빌드
+### 3b. 로컬 Production Archive + 업로드
 
 ```bash
-cd /Users/injoo/Desktop/Dev/fortune/apps/mobile-rn
-
-# Production 빌드 + auto-increment 빌드 번호 (eas.json production 프로필)
-npx eas build --platform ios --profile production --auto-submit
-
-# 또는 auto-submit 없이:
-npx eas build --platform ios --profile production
-# 빌드 완료 후:
-npx eas submit --platform ios --latest
+cd /Users/injoo/Desktop/Dev/fortune
+pnpm rn:native:prepare
+pnpm rn:ios:xcode
 ```
+
+Xcode에서 다음 순서로 진행:
+
+1. Ondo 앱 scheme과 `Any iOS Device (arm64)`를 선택한다.
+2. Team, bundle ID `com.beyond.fortune`, entitlements, extensions, version/build number를 확인한다.
+3. **Product → Archive**를 실행한다.
+4. Organizer에서 archive를 Validate한다.
+5. **Distribute App → App Store Connect → Upload**를 선택한다.
+6. App Store Connect에서 exact version/build가 처리되어 TestFlight에 표시되는지 확인한다.
+
+`eas build`, `eas submit`, `deploy:native`, `deploy:ota`는 기본 절차가 아니다. 사용자가 특정 EAS 작업과 비용/원격 배포를 명시 승인한 경우에만 사용한다.
 
 ### 3c. 빌드 검증
 
-EAS 빌드 페이지에서 로그 확인:
-- [ ] `expo prebuild` 단계 Info.plist/PrivacyInfo 정상 생성
+로컬 Xcode 로그, Organizer, App Store Connect에서 확인:
+- [ ] `pnpm rn:native:prepare` 후 Info.plist/PrivacyInfo 정상 생성
 - [ ] Hermes + New Architecture 활성화 확인
 - [ ] `llama.rn` 네이티브 모듈 링크 성공
 - [ ] dSYM 업로드 성공 (Sentry)
-- [ ] 최종 IPA 업로드 → ASC "Processing"
+- [ ] 로컬 Archive 검증 성공
+- [ ] exact archive 업로드 → ASC "Processing" → TestFlight 표시
 
 ---
 

--- a/docs/audits/2026-06-ondo-security-check/fix-plan-2026-06-10.md
+++ b/docs/audits/2026-06-ondo-security-check/fix-plan-2026-06-10.md
@@ -444,10 +444,7 @@ Review roles:
    supabase functions deploy refresh-private-media-url
    ```
    Add other generated-image functions if touched.
-3. If mobile RN code changed, publish EAS production OTA after gates/commit:
-   ```bash
-   eas update --branch production --message "Security: private media URL refresh"
-   ```
+3. If mobile RN code changed, generate and validate a local Xcode Archive after gates/commit, then upload the exact archive through Organizer to App Store Connect/TestFlight. Do not publish an EAS OTA unless the user explicitly approves that specific remote deployment.
 4. Commit/push and watch GitHub Actions per repo rule.
 
 ### Task 5.4: Final release security report

--- a/docs/deployment/review/IOS_SUBMISSION_AUDIT_2026-05-11.md
+++ b/docs/deployment/review/IOS_SUBMISSION_AUDIT_2026-05-11.md
@@ -1,5 +1,7 @@
 # iOS App Review Submission Audit — 2026-05-11
 
+> Historical audit record. EAS state and commands below document what was inspected on 2026-05-11; they are not the current release procedure. For a new release, follow `docs/development/expo-cng-build-and-release.md`: local Xcode Archive → App Store Connect/TestFlight.
+
 ## Verdict
 
 **NO-GO for immediate upload/submission.**
@@ -151,8 +153,8 @@ OpenClaw using Claude Opus 4.7 independently reviewed the release state and agre
    - restore purchases
    - iPad review path
 7. Update `STORE_REVIEW_MASTER_CHECKLIST.md`, `IOS_REVIEW_EVIDENCE.md`, and `RELEASE_DECISION_LOG.md` from NO-GO to GO with evidence links/paths.
-8. Create a new EAS production iOS build from the clean pushed commit.
-9. Submit the exact new build to App Store Connect and update review notes with the final RC evidence.
+8. Create a new local Xcode Archive from the clean pushed commit.
+9. Upload the exact archive through Xcode Organizer to App Store Connect and update review notes with the final RC evidence.
 
 ## Commands run during this audit
 

--- a/docs/development/expo-cng-build-and-release.md
+++ b/docs/development/expo-cng-build-and-release.md
@@ -1,26 +1,75 @@
-# Ondo Expo CNG build/release policy
+# Ondo Expo CNG local build and release policy
 
-Ondo mobile is an Expo app using Continuous Native Generation (CNG). The repository should treat `apps/mobile-rn/ios` and `apps/mobile-rn/android` as generated output, not source of truth.
+Ondo mobile is an Expo app using Continuous Native Generation (CNG). Expo remains the native-project generator and module ecosystem; **the default iOS binary path is local Xcode Archive → App Store Connect/TestFlight, not EAS Cloud Build**.
 
 ## Source of truth
 
 - App config: `apps/mobile-rn/app.config.js`
-- EAS config: `apps/mobile-rn/eas.json`
+- Legacy emergency EAS config: `apps/mobile-rn/eas.json`
 - iOS extension targets: `apps/mobile-rn/targets/*/expo-target.config.json`
 - Native config plugins: `apps/mobile-rn/plugins/*`
 - Push server payload: `supabase/functions/_shared/notification_push.ts`
+
+`eas.json`, Expo project IDs, and Expo push/update metadata may remain because existing installs, push tokens, or an explicitly approved emergency path can still depend on them. Their presence does not make EAS Cloud Build the normal release path.
 
 ## Do not rely on checked-in native folders
 
 `apps/mobile-rn/.gitignore` ignores `/ios` and `/android`; `git ls-files apps/mobile-rn/ios` and `git ls-files apps/mobile-rn/android` should both stay at `0`.
 
-If a native change is needed, express it through Expo config, a config plugin, or an Expo target, then regenerate via Expo/EAS.
+Express native changes through Expo config, a config plugin, or an Expo target, then regenerate locally:
 
-## Build/update rule
+```bash
+pnpm install
+pnpm rn:native:prepare
+pnpm rn:native:doctor
+```
 
-- JS/TS/UI-only changes with unchanged native runtime: use `npm run deploy:ota --workspace @fortune/mobile-rn`.
-- Native capability, entitlement, extension, notification service, app icon, plist, pods, or native dependency changes: use EAS native build.
-- iOS notification sender/avatar behavior is native. It cannot be fixed by OTA alone; users need a new TestFlight/App Store build containing the Notification Service Extension and entitlements.
+## Default build and release rule
+
+- Local development and simulator QA: `pnpm rn:native:build` or `pnpm rn:ios:local`.
+- Physical-iPhone development QA: `pnpm rn:native:device:run`.
+- Any release-bound JS/TS/UI or native change: create a new local iOS archive and upload that archive to App Store Connect/TestFlight.
+- Native capability, entitlement, extension, notification service, app icon, plist, pods, or dependency changes require a new binary. They cannot be delivered by OTA alone.
+- `deploy:native` and `deploy:ota` are legacy compatibility commands. Do not run them unless the user explicitly requests and approves the specific EAS Cloud Build or EAS Update operation.
+
+EAS Update is not the same as EAS Cloud Build, but it is also not Ondo's default release path. A change being OTA-compatible does not authorize an OTA publish.
+
+## Local Xcode Archive → TestFlight
+
+1. Start from a clean, frozen release SHA and make sure the version/build number in `app.config.js` is correct.
+2. Generate the native project and pods locally:
+
+   ```bash
+   pnpm install
+   pnpm rn:native:prepare
+   pnpm rn:native:doctor
+   ```
+
+3. Open the generated workspace:
+
+   ```bash
+   pnpm rn:ios:xcode
+   ```
+
+4. In Xcode, select the Ondo app scheme and `Any iOS Device (arm64)` or a connected release device.
+5. Confirm the Apple team, bundle ID `com.beyond.fortune`, signing, entitlements, app extensions, version, and build number.
+6. Choose **Product → Archive**.
+7. In Organizer, validate the archive, then choose **Distribute App → App Store Connect → Upload**.
+8. Wait for App Store Connect processing and verify that the exact uploaded build appears in TestFlight.
+9. Install that build on a real iPhone and run the release-specific smoke checks before claiming phone application.
+
+TestFlight is the distribution channel, not the builder. There is no TestFlight per-upload build fee, but Apple Developer Program membership remains separate from Expo pricing.
+
+## Verification before claiming fixed or released
+
+1. `npx expo config --type introspect --json` confirms the generated config includes the expected bundle ID and entitlements.
+2. `pnpm rn:native:build` succeeds for a local simulator build when applicable.
+3. Xcode Organizer shows a successful local archive with the exact release SHA/version/build metadata.
+4. App Store Connect finishes processing the uploaded archive and exposes the exact build in TestFlight.
+5. A real iPhone installs that build and passes the affected runtime checks.
+6. For push/avatar changes, a real push payload includes the expected character ID/image and the Notification Service Extension behavior is observed on device.
+
+Do not report “TestFlight complete” from an archive alone, and do not report “applied to the physical phone” from an upload alone.
 
 ## Push avatar implementation
 
@@ -31,17 +80,10 @@ Ondo uses Expo Push API plus an iOS Notification Service Extension generated thr
 3. `targets/notification-service/NotificationService.swift` attaches the character image and applies iOS Communication Notification metadata.
 4. iOS still shows the app icon as the app source icon. The character face can appear as sender/avatar/rich attachment where iOS permits it.
 
-## Verification before claiming fixed
-
-1. `npx expo config --type introspect --json` confirms generated config includes:
-   - `ios.bundleIdentifier = com.beyond.fortune`
-   - `ios.entitlements.aps-environment = production`
-   - `ios.entitlements.com.apple.developer.usernotifications.communication = true`
-   - `updates.url = https://u.expo.dev/f7a724ea-b46e-494a-b83c-94e7a6fec02a`
-2. EAS build finishes with `distribution = STORE`.
-3. Build is processed and available in TestFlight/App Store Connect.
-4. A real device installs the new build and receives a real push payload that includes a character id and image.
-
 ## Important limitation
 
-"Fully Expo" here means Expo CNG/EAS-managed native generation, not Expo Go. Ondo depends on native modules and native targets (`expo-dev-client`, IAP, ads, llama.rn, notification service extension, widgets), so Expo Go cannot represent production behavior.
+"Fully Expo" here means Expo CNG-generated native projects, not Expo Go and not mandatory EAS Cloud Build. Ondo depends on native modules and targets (`expo-dev-client`, IAP, ads, `llama.rn`, notification service extension, widgets), so Expo Go cannot represent production behavior.
+
+## Historical documents
+
+Dated files under `docs/audits/`, `docs/deployment/review/`, and `artifacts/` may record EAS builds that actually happened. Keep those facts as evidence, but do not use their old imperative commands as the current release procedure. This document and `CLAUDE.md` are the current operational source of truth.

--- a/docs/development/local-native-ios-testing.md
+++ b/docs/development/local-native-ios-testing.md
@@ -2,6 +2,8 @@
 
 Use this path when you want to test Ondo without Expo Go, Expo tunnel, EAS build, or EAS OTA spend.
 
+Production iOS binaries follow the same local-native principle: generate locally, archive in Xcode, and upload through Organizer to App Store Connect/TestFlight. See [Expo CNG local build and release policy](expo-cng-build-and-release.md).
+
 ## What this is
 
 - Local native iOS testing via Xcode / iOS Simulator / physical iPhone.
@@ -131,13 +133,13 @@ For install/launch, the iPhone must be connected and available to CoreDevice/dev
 
 If the phone is paired but the tunnel is unavailable, the helper fails early with a clear message instead of claiming the real-phone run succeeded.
 
-## Existing Expo commands
+## Legacy Expo deployment commands
 
-The old commands still exist for compatibility:
+The old commands still exist for compatibility, not as the default release path:
 
 - `pnpm --filter @fortune/mobile-rn start`
 - `pnpm --filter @fortune/mobile-rn ios`
 - `pnpm --filter @fortune/mobile-rn deploy:ota`
 - `pnpm --filter @fortune/mobile-rn deploy:native`
 
-Do not use `deploy:ota` or `deploy:native` unless the user explicitly approves EAS spend/deployment.
+Do not use `deploy:ota` or `deploy:native` unless the user explicitly approves that specific EAS spend/deployment. For a normal release, use local Xcode Archive → Organizer upload → TestFlight verification.

--- a/docs/features/PROACTIVE_MESSAGING_PLAN.md
+++ b/docs/features/PROACTIVE_MESSAGING_PLAN.md
@@ -534,9 +534,9 @@ V1: DB row가 없으면 디폴트 값으로 동작. UI 없이도 시스템 동�
 2. DB 마이그레이션: `supabase db push --include-all`
 3. Edge Function deploy:
    - `supabase functions deploy proactive-message-dispatch character-chat generate-character-proactive-image`
-4. RN OTA: `cd apps/mobile-rn && eas update --branch production`
+4. 모바일 클라이언트 반영: Edge 배포 후 새 로컬 Xcode Archive를 만들고 Organizer에서 TestFlight로 업로드한다.
 
-OTA 가능. native module 추가 없음. runtime bump 불요.
+네이티브 모듈 추가는 없지만 OTA 호환 여부가 원격 배포 승인을 뜻하지는 않는다. 현재 기본 경로는 로컬 바이너리 배포이며, EAS Update는 사용자가 이 작업에 명시 승인한 경우에만 사용한다.
 
 `/ultrareview` 자동 트리거 (DB 마이그레이션 변경 + Edge Function = CLAUDE.md 룰).
 

--- a/plan-fortune-pricing-sot.md
+++ b/plan-fortune-pricing-sot.md
@@ -140,8 +140,8 @@ supabase/functions/_shared/
 
 ## 배포 순서
 
-1. PR 머지 후 OTA — generated 파일은 Edge 코드라 OTA 가 아니라 `supabase functions deploy soul-consume payment-verify-purchase` 등 모든 Edge 재배포.
-2. 클라 OTA 는 별도 (`eas update --branch production`). 단 Edge 와 클라가 잠깐 다른 가격 보면 안 됨 — Edge 먼저 배포 후 클라.
+1. PR 머지 후 generated Edge 코드는 `supabase functions deploy soul-consume payment-verify-purchase` 등 해당 함수를 먼저 재배포한다.
+2. 클라이언트는 Edge 배포 확인 후 로컬 Xcode Archive를 만들고 TestFlight에 업로드한다. EAS Update는 기본 경로가 아니며, 사용자가 이 작업의 원격 배포를 명시 승인한 경우에만 사용한다.
 3. 사용자 잔액/차감 모니터링 (Supabase logs).
 
 ## GSTACK REVIEW REPORT


### PR DESCRIPTION
## Summary
- make local Xcode Archive → App Store Connect/TestFlight the default Ondo iOS release path
- mark EAS Build/Submit/Update and legacy deploy commands as explicit-approval emergency paths only
- preserve dated EAS build/audit evidence while marking it historical
- separate EAS cloud-build cost from TestFlight and Apple Developer Program

## Verification
- `git diff --check`
- all documented root scripts resolved in `package.json`
- no newly introduced broken relative Markdown links
- pre-commit classified the final staged diff as non-native and passed

## Scope
Documentation only. No app build upload, EAS operation, TestFlight submission, backend deploy, or database change was performed.