### PR TITLE
[NO-JIRA] Redesign ONDO web home

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,11 +1,47 @@
 /* 웹 전역 베이스 스타일.
- *
- * 색/간격/서체 값은 전부 tokens.css 의 --ondo-* 를 통해서만 참조한다.
- * 하드코딩 색상 금지 (CLAUDE.md 디자인 시스템 규칙).
- *
- * dark 전용 — createFortuneTheme('light') 는 repo 전체 호출부가 0 이라
- * [data-theme] 분기를 두지 않는다.
+ * packages/design-tokens 는 모바일과 공유하므로 웹의 Warm Celestial Editorial
+ * 팔레트는 여기에서 토큰 별칭으로만 덮어쓴다. 컴포넌트는 계속 --ondo-* 만 쓴다.
  */
+
+:root {
+  --ondo-color-accent: #4b1635;
+  --ondo-color-accent-hover: #351025;
+  --ondo-color-accent-light: #eadccf;
+  --ondo-color-accent-secondary: #6d254b;
+  --ondo-color-accent-tertiary: #9a623d;
+  --ondo-color-background: #f7f2ea;
+  --ondo-color-background-secondary: #efe5d9;
+  --ondo-color-background-tertiary: #e6d9ca;
+  --ondo-color-surface: #fffaf4;
+  --ondo-color-surface-secondary: #f4ece2;
+  --ondo-color-surface-elevated: #fffdf9;
+  --ondo-color-text-primary: #191716;
+  --ondo-color-text-secondary: #625952;
+  --ondo-color-text-tertiary: #82766d;
+  --ondo-color-text-subtitle: #423b37;
+  --ondo-color-border: #d9ccbd;
+  --ondo-color-border-opaque: #cfc0af;
+  --ondo-color-divider: #d9ccbd;
+  --ondo-color-user-bubble: #eee3d7;
+  --ondo-color-cta-background: #4b1635;
+  --ondo-color-cta-foreground: #fffaf4;
+  --ondo-color-secondary-background: #fffaf4;
+  --ondo-color-secondary-foreground: #4b1635;
+  --ondo-color-overlay: rgba(25, 23, 22, 0.42);
+  --ondo-color-chip-blue: #dbe5e5;
+  --ondo-color-chip-green: #dce5d6;
+  --ondo-color-chip-peach: #efd9cd;
+  --ondo-color-chip-lavender: #e4dae8;
+  --ondo-color-chip-text: #292323;
+  --ondo-color-accent-pressed: #351025;
+  --ondo-color-accent-subtle: rgba(75, 22, 53, 0.08);
+  --ondo-color-celestial: #2f1328;
+  --ondo-color-celestial-text: #fff9f1;
+  --ondo-color-celestial-accent: #d9b47d;
+  --ondo-font-serif: 'MaruBuri', 'AppleMyungjo', 'Noto Serif KR', Georgia, serif;
+  --ondo-font-sans: -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo', 'Pretendard',
+    'Noto Sans KR', 'Segoe UI', Roboto, sans-serif;
+}
 
 *,
 *::before,
@@ -14,17 +50,16 @@
 }
 
 html {
-  color-scheme: dark;
+  color-scheme: light;
   -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
 }
 
 body {
   margin: 0;
   background: var(--ondo-color-background);
   color: var(--ondo-color-text-primary);
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo', 'Pretendard',
-    'Noto Sans KR', 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--ondo-font-sans);
   font-size: var(--ondo-typography-body-large-font-size);
   line-height: var(--ondo-typography-body-large-line-height);
   word-break: keep-all;
@@ -53,13 +88,13 @@ textarea {
 
 :focus-visible {
   outline: 2px solid var(--ondo-color-accent-secondary);
-  outline-offset: 2px;
+  outline-offset: 3px;
 }
 
 /* --- 공용 레이아웃 --- */
 
 .ondo-shell {
-  max-width: 720px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: var(--ondo-spacing-xl) var(--ondo-spacing-page-horizontal)
     var(--ondo-spacing-xxxxl);
@@ -78,10 +113,11 @@ textarea {
   font-weight: var(--ondo-typography-kicker-font-weight);
   letter-spacing: var(--ondo-typography-kicker-letter-spacing);
   text-transform: uppercase;
-  color: var(--ondo-color-text-tertiary);
+  color: var(--ondo-color-accent-tertiary);
 }
 
 .ondo-h1 {
+  font-family: var(--ondo-font-serif);
   font-size: var(--ondo-typography-display-small-font-size);
   line-height: var(--ondo-typography-display-small-line-height);
   font-weight: var(--ondo-typography-display-small-font-weight);
@@ -89,12 +125,14 @@ textarea {
 }
 
 .ondo-h2 {
+  font-family: var(--ondo-font-serif);
   font-size: var(--ondo-typography-heading2-font-size);
   line-height: var(--ondo-typography-heading2-line-height);
   font-weight: var(--ondo-typography-heading2-font-weight);
 }
 
 .ondo-h3 {
+  font-family: var(--ondo-font-serif);
   font-size: var(--ondo-typography-heading4-font-size);
   line-height: var(--ondo-typography-heading4-line-height);
   font-weight: var(--ondo-typography-heading4-font-weight);
@@ -102,8 +140,8 @@ textarea {
 
 .ondo-muted {
   color: var(--ondo-color-text-secondary);
-  font-size: var(--ondo-typography-body-medium-font-size);
-  line-height: var(--ondo-typography-body-medium-line-height);
+  font-size: var(--ondo-typography-body-large-font-size);
+  line-height: var(--ondo-typography-body-large-line-height);
 }
 
 .ondo-stack {
@@ -133,6 +171,12 @@ textarea {
   font-size: var(--ondo-typography-label-large-font-size);
   font-weight: var(--ondo-typography-label-large-font-weight);
   cursor: pointer;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.ondo-button:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-2px);
 }
 
 .ondo-button:disabled {
@@ -197,8 +241,199 @@ textarea {
   gap: var(--ondo-spacing-sm);
 }
 
+/* --- 공통 헤더 / 푸터 --- */
+
+.ondo-site-header {
+  position: sticky;
+  z-index: 50;
+  top: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--ondo-color-border) 78%, transparent);
+  background: color-mix(in srgb, var(--ondo-color-background) 92%, transparent);
+  backdrop-filter: blur(16px);
+}
+
+.ondo-site-nav {
+  display: flex;
+  width: min(100% - 40px, 1200px);
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  margin-inline: auto;
+}
+
+.ondo-site-logo {
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: 25px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.ondo-desktop-nav,
+.ondo-header-actions,
+.ondo-mobile-menu nav {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+}
+
+.ondo-desktop-nav {
+  margin-left: auto;
+}
+
+.ondo-desktop-nav a,
+.ondo-mobile-menu a {
+  color: var(--ondo-color-text-secondary);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.ondo-desktop-nav a:hover,
+.ondo-mobile-menu a:hover {
+  color: var(--ondo-color-accent);
+}
+
+.ondo-login-link {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  padding-inline: 17px;
+  border: 1px solid var(--ondo-color-border-opaque);
+  border-radius: 999px;
+  color: var(--ondo-color-text-primary);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.ondo-mobile-menu {
+  display: none;
+  position: relative;
+}
+
+.ondo-mobile-menu summary {
+  padding: 8px 12px;
+  border: 1px solid var(--ondo-color-border-opaque);
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 800;
+  list-style: none;
+}
+
+.ondo-mobile-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.ondo-mobile-menu nav {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(280px, calc(100vw - 32px));
+  align-items: stretch;
+  flex-direction: column;
+  gap: 0;
+  padding: 10px;
+  border: 1px solid var(--ondo-color-border);
+  background: var(--ondo-color-surface-elevated);
+  box-shadow: 0 18px 50px rgba(25, 23, 22, 0.12);
+}
+
+.ondo-mobile-menu nav a {
+  padding: 12px 10px;
+}
+
+.ondo-site-footer {
+  border-top: 1px solid var(--ondo-color-border);
+  background: var(--ondo-color-surface);
+}
+
+.ondo-footer-inner {
+  display: grid;
+  width: min(100% - 40px, 1200px);
+  grid-template-columns: 1fr auto;
+  gap: 40px;
+  margin-inline: auto;
+  padding: 58px 0 38px;
+}
+
+.ondo-footer-brand {
+  max-width: 560px;
+}
+
+.ondo-footer-brand strong {
+  display: block;
+  margin-bottom: 14px;
+  font-family: var(--ondo-font-serif);
+  font-size: 24px;
+}
+
+.ondo-footer-brand p {
+  color: var(--ondo-color-text-tertiary);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.ondo-footer-links {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+
+.ondo-footer-links a {
+  color: var(--ondo-color-text-secondary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.ondo-footer-bottom {
+  width: min(100% - 40px, 1200px);
+  margin-inline: auto;
+  padding: 20px 0 26px;
+  border-top: 1px solid var(--ondo-color-border);
+  color: var(--ondo-color-text-tertiary);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 760px) {
+  .ondo-site-nav,
+  .ondo-footer-inner,
+  .ondo-footer-bottom {
+    width: min(100% - 32px, 1200px);
+  }
+
+  .ondo-desktop-nav,
+  .ondo-header-actions {
+    display: none;
+  }
+
+  .ondo-mobile-menu {
+    display: block;
+  }
+
+  .ondo-footer-inner {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 480px) {
   .ondo-grid-2 {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .ondo-button {
+    transition: none;
+  }
+
+  .ondo-button:hover:not(:disabled) {
+    transform: none;
   }
 }

--- a/apps/web/src/app/home.module.css
+++ b/apps/web/src/app/home.module.css
@@ -1,0 +1,879 @@
+.home {
+  width: 100%;
+  overflow: hidden;
+}
+
+.hero {
+  border-bottom: 1px solid var(--ondo-color-border);
+  background:
+    radial-gradient(circle at 78% 26%, var(--ondo-color-accent-light), transparent 24rem),
+    var(--ondo-color-background);
+}
+
+.heroInner,
+.section,
+.finalCta {
+  width: min(100% - 40px, 1200px);
+  margin-inline: auto;
+}
+
+.heroInner {
+  display: grid;
+  grid-template-columns: minmax(0, 1.04fr) minmax(360px, 0.96fr);
+  align-items: center;
+  gap: 72px;
+  min-height: 650px;
+  padding: 88px 0 72px;
+}
+
+.heroCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: 650px;
+}
+
+.eyebrow,
+.cardKicker,
+.letterKicker,
+.resultDate {
+  margin: 0 0 18px;
+  color: var(--ondo-color-accent-tertiary);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.heroCopy h1 {
+  margin: 0;
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: clamp(42px, 5vw, 68px);
+  font-weight: 600;
+  letter-spacing: -0.045em;
+  line-height: 1.18;
+}
+
+.heroDescription {
+  max-width: 580px;
+  margin: 28px 0 0;
+  color: var(--ondo-color-text-secondary);
+  font-size: 18px;
+  line-height: 1.8;
+}
+
+.heroActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-top: 34px;
+}
+
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 52px;
+  gap: 14px;
+  padding: 0 24px;
+  border: 1px solid var(--ondo-color-cta-background);
+  border-radius: 999px;
+  background: var(--ondo-color-cta-background);
+  color: var(--ondo-color-cta-foreground);
+  font-size: 16px;
+  font-weight: 800;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.primaryButton:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
+.textLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  border-bottom: 1px solid currentColor;
+  color: var(--ondo-color-text-primary);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.7;
+}
+
+.heroNote {
+  margin: 18px 0 0;
+  color: var(--ondo-color-text-tertiary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.heroVisual {
+  position: relative;
+  display: grid;
+  min-height: 460px;
+  place-items: center;
+}
+
+.sunHalo {
+  position: absolute;
+  top: 2px;
+  right: 12%;
+  display: grid;
+  width: 174px;
+  height: 174px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--ondo-color-accent-tertiary) 45%, transparent);
+  border-radius: 50%;
+  color: var(--ondo-color-accent-tertiary);
+  font-family: var(--ondo-font-serif);
+  font-size: 86px;
+  opacity: 0.65;
+}
+
+.previewLetter {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 420px);
+  margin-top: 46px;
+  padding: 42px;
+  border: 1px solid var(--ondo-color-border);
+  background: var(--ondo-color-surface-elevated);
+  box-shadow: 0 24px 70px color-mix(in srgb, var(--ondo-color-text-primary) 10%, transparent);
+  transform: rotate(1.5deg);
+}
+
+.previewLetter::before {
+  position: absolute;
+  inset: 11px;
+  border: 1px solid color-mix(in srgb, var(--ondo-color-border) 65%, transparent);
+  content: '';
+  pointer-events: none;
+}
+
+.letterKicker {
+  margin-bottom: 22px;
+}
+
+.letterQuote {
+  position: relative;
+  margin: 0;
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: 27px;
+  font-weight: 600;
+  line-height: 1.55;
+}
+
+.letterDetails {
+  display: grid;
+  gap: 12px;
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid var(--ondo-color-border);
+  color: var(--ondo-color-text-secondary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.letterDetails span {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  gap: 12px;
+}
+
+.letterDetails strong {
+  color: var(--ondo-color-accent-tertiary);
+}
+
+.letterConversation {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 24px;
+  padding: 14px;
+  border-radius: 10px;
+  background: var(--ondo-color-background-secondary);
+  color: var(--ondo-color-text-secondary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.miniAvatar,
+.resultAvatar {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--ondo-color-chip-blue);
+  color: var(--ondo-color-chip-text);
+  font-family: var(--ondo-font-serif);
+  font-weight: 700;
+}
+
+.miniAvatar {
+  width: 34px;
+  height: 34px;
+}
+
+.trustStrip {
+  display: grid;
+  width: min(100% - 40px, 1200px);
+  margin-inline: auto;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-top: 1px solid var(--ondo-color-border);
+}
+
+.trustItem {
+  display: flex;
+  gap: 16px;
+  padding: 28px 26px;
+  border-left: 1px solid var(--ondo-color-border);
+}
+
+.trustItem:first-child {
+  border-left: 0;
+}
+
+.trustNumber {
+  color: var(--ondo-color-accent-tertiary);
+  font-family: var(--ondo-font-serif);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.trustItem p {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.trustItem strong {
+  color: var(--ondo-color-text-primary);
+}
+
+.trustItem p span {
+  color: var(--ondo-color-text-tertiary);
+}
+
+.section {
+  padding-block: 112px;
+}
+
+.sectionHeading {
+  max-width: 680px;
+}
+
+.sectionHeading h2,
+.finalCta h2 {
+  margin: 0;
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: clamp(34px, 4vw, 52px);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.28;
+}
+
+.sectionHeading > p:last-child {
+  margin: 20px 0 0;
+  color: var(--ondo-color-text-secondary);
+  font-size: 17px;
+  line-height: 1.75;
+}
+
+.sectionHeadingRow {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 48px;
+}
+
+.sectionHeadingRow .sectionHeading p:last-child {
+  max-width: 680px;
+}
+
+.purposeGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 48px;
+  border-top: 1px solid var(--ondo-color-border);
+  border-bottom: 1px solid var(--ondo-color-border);
+}
+
+.purposeCard {
+  position: relative;
+  min-height: 290px;
+  padding: 32px 28px;
+  border-left: 1px solid var(--ondo-color-border);
+  transition: background 200ms ease;
+}
+
+.purposeCard:first-child {
+  border-left: 0;
+}
+
+.purposeCard:hover {
+  background: var(--ondo-color-surface);
+}
+
+.purposeMark {
+  display: block;
+  margin-bottom: 44px;
+  color: var(--ondo-color-accent-tertiary);
+  font-family: var(--ondo-font-serif);
+  font-size: 42px;
+  line-height: 1;
+}
+
+.cardKicker {
+  display: block;
+  margin-bottom: 10px;
+}
+
+.purposeCard h3,
+.fortuneCard h3,
+.characterCard h3 {
+  margin: 0;
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: 23px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.purposeCard p,
+.fortuneCard p,
+.characterCard p {
+  margin: 12px 0 0;
+  color: var(--ondo-color-text-secondary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.cardArrow {
+  position: absolute;
+  right: 28px;
+  bottom: 28px;
+  color: var(--ondo-color-accent-tertiary);
+  font-size: 20px;
+}
+
+.featuredSection,
+.characterSection {
+  position: relative;
+}
+
+.featuredSection::before,
+.characterSection::before {
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 100vw;
+  background: var(--ondo-color-background-secondary);
+  content: '';
+  transform: translateX(-50%);
+}
+
+.fortuneGrid,
+.characterGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.fortuneCard {
+  display: flex;
+  min-height: 326px;
+  flex-direction: column;
+  padding: 28px;
+  border: 1px solid var(--ondo-color-border);
+  background: var(--ondo-color-surface);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.fortuneCard:hover,
+.characterCard:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 40px color-mix(in srgb, var(--ondo-color-text-primary) 9%, transparent);
+}
+
+.fortuneCardTop {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 54px;
+}
+
+.fortuneMark {
+  display: grid;
+  width: 70px;
+  height: 70px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--ondo-card-tint, var(--ondo-color-background-secondary));
+  color: var(--ondo-color-accent-tertiary);
+  font-family: var(--ondo-font-serif);
+  font-size: 34px;
+}
+
+.fortuneCard[data-tone='lavender'] { --ondo-card-tint: var(--ondo-color-chip-lavender); }
+.fortuneCard[data-tone='rose'] { --ondo-card-tint: var(--ondo-color-chip-peach); }
+.fortuneCard[data-tone='sage'] { --ondo-card-tint: var(--ondo-color-chip-green); }
+
+.cost {
+  padding: 5px 9px;
+  border: 1px solid var(--ondo-color-border);
+  border-radius: 999px;
+  color: var(--ondo-color-text-tertiary);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.fortuneCard p {
+  flex: 1;
+}
+
+.readLink {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 28px;
+  padding-top: 16px;
+  border-top: 1px solid var(--ondo-color-border);
+  color: var(--ondo-color-text-primary);
+  font-size: 16px;
+  font-weight: 800;
+}
+
+.resultSection {
+  padding-bottom: 128px;
+}
+
+.resultSection .sectionHeading {
+  margin-bottom: 48px;
+}
+
+.resultCard {
+  position: relative;
+  display: grid;
+  overflow: hidden;
+  grid-template-columns: minmax(0, 1.55fr) minmax(260px, 0.45fr);
+  border-radius: 2px;
+  background: var(--ondo-color-celestial);
+  color: var(--ondo-color-celestial-text);
+  box-shadow: 0 28px 80px color-mix(in srgb, var(--ondo-color-celestial) 24%, transparent);
+}
+
+.resultStars {
+  position: absolute;
+  top: 28px;
+  right: 34px;
+  color: var(--ondo-color-celestial-accent);
+  font-family: var(--ondo-font-serif);
+  opacity: 0.7;
+}
+
+.resultMain {
+  padding: 64px;
+}
+
+.resultDate {
+  color: var(--ondo-color-celestial-accent);
+}
+
+.resultMain h3 {
+  max-width: 680px;
+  margin: 0;
+  font-family: var(--ondo-font-serif);
+  font-size: clamp(32px, 4vw, 48px);
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.resultBody {
+  max-width: 720px;
+  margin: 30px 0 0;
+  color: color-mix(in srgb, var(--ondo-color-celestial-text) 78%, transparent);
+  font-family: var(--ondo-font-serif);
+  font-size: 17px;
+  line-height: 1.9;
+}
+
+.resultSignals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 46px;
+}
+
+.resultSignals span {
+  display: flex;
+  min-height: 96px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--ondo-color-celestial-text) 16%, transparent);
+  color: var(--ondo-color-celestial-text);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.resultSignals small {
+  color: var(--ondo-color-celestial-accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.resultAside {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 44px 34px;
+  border-left: 1px solid color-mix(in srgb, var(--ondo-color-celestial-text) 14%, transparent);
+  background: color-mix(in srgb, var(--ondo-color-celestial-text) 4%, transparent);
+}
+
+.resultAvatar {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 24px;
+  font-size: 24px;
+}
+
+.resultAside p {
+  margin: 0;
+  color: color-mix(in srgb, var(--ondo-color-celestial-text) 86%, transparent);
+  font-family: var(--ondo-font-serif);
+  font-size: 18px;
+  line-height: 1.75;
+}
+
+.resultAside a {
+  margin-top: 28px;
+  color: var(--ondo-color-celestial-accent);
+  font-size: 16px;
+  font-weight: 800;
+}
+
+.characterGrid {
+  gap: 1px;
+  border: 1px solid var(--ondo-color-border);
+  background: var(--ondo-color-border);
+}
+
+.characterCard {
+  display: flex;
+  min-height: 410px;
+  flex-direction: column;
+  padding: 26px;
+  background: var(--ondo-color-surface);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.characterPortrait {
+  display: grid;
+  height: 190px;
+  margin: -26px -26px 28px;
+  place-items: center;
+  background:
+    radial-gradient(circle at 50% 42%, color-mix(in srgb, var(--ondo-color-surface) 64%, transparent) 0 22%, transparent 23%),
+    linear-gradient(150deg, var(--ondo-color-chip-blue), var(--ondo-color-background-secondary));
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: 52px;
+  font-weight: 600;
+}
+
+.characterPortrait[data-index='1'] { background: linear-gradient(150deg, var(--ondo-color-chip-peach), var(--ondo-color-background-secondary)); }
+.characterPortrait[data-index='2'] { background: linear-gradient(150deg, var(--ondo-color-chip-green), var(--ondo-color-background-secondary)); }
+.characterPortrait[data-index='3'] { background: linear-gradient(150deg, var(--ondo-color-chip-lavender), var(--ondo-color-background-secondary)); }
+
+.characterCard p {
+  flex: 1;
+}
+
+.characterTags {
+  margin-top: 20px;
+  color: var(--ondo-color-accent-tertiary);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.guideSection {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.25fr);
+  gap: 88px;
+}
+
+.guideSteps {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.guideSteps li {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  column-gap: 18px;
+  padding: 26px 0;
+  border-top: 1px solid var(--ondo-color-border);
+}
+
+.guideSteps li:last-child {
+  border-bottom: 1px solid var(--ondo-color-border);
+}
+
+.guideSteps li > span {
+  grid-row: span 2;
+  color: var(--ondo-color-accent-tertiary);
+  font-family: var(--ondo-font-serif);
+  font-size: 30px;
+  font-style: italic;
+}
+
+.guideSteps strong {
+  color: var(--ondo-color-text-primary);
+  font-family: var(--ondo-font-serif);
+  font-size: 21px;
+}
+
+.guideSteps p {
+  margin: 8px 0 0;
+  color: var(--ondo-color-text-secondary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.guideNote {
+  grid-column: 2;
+  margin: -58px 0 0 66px;
+  color: var(--ondo-color-text-tertiary);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.finalCta {
+  display: flex;
+  min-height: 420px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-block: 84px;
+  border-top: 1px solid var(--ondo-color-border);
+  text-align: center;
+}
+
+.finalCta h2 {
+  max-width: 850px;
+}
+
+.finalCta .primaryButton {
+  margin-top: 34px;
+}
+
+@media (max-width: 980px) {
+  .heroInner {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 30px;
+    padding-top: 64px;
+  }
+
+  .heroCopy {
+    max-width: 760px;
+  }
+
+  .heroVisual {
+    min-height: 420px;
+  }
+
+  .trustStrip,
+  .purposeGrid,
+  .fortuneGrid,
+  .characterGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .trustItem:nth-child(3) {
+    border-left: 0;
+  }
+
+  .trustItem:nth-child(n + 3) {
+    border-top: 1px solid var(--ondo-color-border);
+  }
+
+  .purposeCard:nth-child(3) {
+    border-left: 0;
+  }
+
+  .purposeCard:nth-child(n + 3) {
+    border-top: 1px solid var(--ondo-color-border);
+  }
+
+  .resultCard,
+  .guideSection {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .resultAside {
+    border-top: 1px solid color-mix(in srgb, var(--ondo-color-celestial-text) 14%, transparent);
+    border-left: 0;
+  }
+
+  .guideNote {
+    grid-column: 1;
+    margin: -58px 0 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .heroInner,
+  .section,
+  .finalCta,
+  .trustStrip {
+    width: min(100% - 32px, 1200px);
+  }
+
+  .heroInner {
+    min-height: auto;
+    padding: 52px 0 30px;
+  }
+
+  .heroCopy h1 {
+    font-size: 40px;
+    line-height: 1.24;
+  }
+
+  .heroDescription {
+    font-size: 16px;
+  }
+
+  .heroActions {
+    width: 100%;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .primaryButton {
+    width: 100%;
+  }
+
+  .textLink {
+    align-self: flex-start;
+  }
+
+  .heroVisual {
+    min-height: 390px;
+  }
+
+  .sunHalo {
+    right: -22px;
+  }
+
+  .previewLetter {
+    padding: 34px 28px;
+    transform: none;
+  }
+
+  .letterQuote {
+    font-size: 23px;
+  }
+
+  .trustStrip,
+  .purposeGrid,
+  .fortuneGrid,
+  .characterGrid,
+  .resultSignals {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .trustItem,
+  .trustItem:nth-child(2) {
+    border-top: 1px solid var(--ondo-color-border);
+    border-left: 0;
+  }
+
+  .purposeCard,
+  .purposeCard:nth-child(2),
+  .purposeCard:nth-child(4) {
+    border-top: 1px solid var(--ondo-color-border);
+    border-left: 0;
+  }
+
+  .section {
+    padding-block: 78px;
+  }
+
+  .sectionHeadingRow {
+    align-items: flex-start;
+    flex-direction: column;
+    margin-bottom: 36px;
+  }
+
+  .sectionHeading h2,
+  .finalCta h2 {
+    font-size: 34px;
+  }
+
+  .purposeGrid {
+    margin-top: 36px;
+  }
+
+  .purposeCard {
+    min-height: 250px;
+  }
+
+  .fortuneCard {
+    min-height: 300px;
+  }
+
+  .resultMain {
+    padding: 40px 26px;
+  }
+
+  .resultMain h3 {
+    font-size: 31px;
+  }
+
+  .resultAside {
+    padding: 32px 26px;
+  }
+
+  .guideSection {
+    gap: 38px;
+  }
+
+  .guideNote {
+    margin: 0;
+  }
+
+  .finalCta {
+    min-height: 380px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primaryButton,
+  .fortuneCard,
+  .characterCard {
+    transition: none;
+  }
+
+  .primaryButton:hover,
+  .fortuneCard:hover,
+  .characterCard:hover {
+    transform: none;
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,91 +1,236 @@
 import Link from 'next/link';
-import { CHAT_INDEX_HREF, FORTUNE_INDEX_HREF, fortuneHref } from '@/lib/href';
 
-import { getFortuneCostPoints } from '@fortune/product-contracts';
+import { WEB_CHAT_CHARACTERS } from '@/features/chat/characters';
+import { WEB_FORTUNES, type WebFortune } from '@/features/fortune/catalog';
+import {
+  CHAT_INDEX_HREF,
+  FORTUNE_INDEX_HREF,
+  chatHref,
+  fortuneHref,
+} from '@/lib/href';
 
-import { FortuneLinkCard } from '@/components/fortune-link-card';
-import { WEB_FORTUNES } from '@/features/fortune/catalog';
+import styles from './home.module.css';
 
-/**
- * 주 CTA 는 `/운세/오늘` 하나로 유지한다 — 첫 방문자가 결과까지 가는 경로 중
- * 실제로 검증된 건 이거다. 나머지 운세와 대화는 그 아래에서 전부 눈에 보이고
- * 닿을 수 있게 둔다 (설치 없이도 쓸 게 있다는 걸 첫 화면에서 알려야 한다).
- */
-const OTHER_FORTUNES = WEB_FORTUNES.filter((fortune) => fortune.fortuneType !== 'daily');
+const FEATURED = [
+  { type: 'daily', label: '오늘의 운세', mark: '☼', tone: 'sand' },
+  { type: 'tarot', label: '오늘의 타로', mark: '◇', tone: 'lavender' },
+  { type: 'love', label: '연애운', mark: '♡', tone: 'rose' },
+  { type: 'wealth', label: '재물운', mark: '✦', tone: 'sage' },
+] as const;
 
-const highlights = [
+const PURPOSES = [
   {
-    kicker: 'SAJU',
-    title: '생년월일시로 읽는 오늘',
-    body: '만세력 기반으로 사주를 세운 뒤, 오늘 하루의 흐름을 종합·애정·재물·일·학업·건강으로 나눠 정리합니다.',
+    label: '오늘',
+    title: '하루의 흐름과 타이밍',
+    description: '지금 밀어도 되는 일과 잠시 두어야 할 일을 봐요.',
+    slug: '오늘',
+    mark: '☼',
   },
   {
-    kicker: 'CHARACTER',
-    title: '나를 기억하는 캐릭터',
-    body: '대화가 쌓일수록 관계가 달라집니다. 처음 만난 사이와 오래 본 사이의 말투가 같지 않습니다.',
+    label: '사랑',
+    title: '마음과 관계의 온도',
+    description: '관계에서 놓치고 있던 감정의 방향을 짚어봐요.',
+    slug: '연애',
+    mark: '♡',
   },
-];
+  {
+    label: '일과 돈',
+    title: '커리어와 금전의 방향',
+    description: '오늘 집중할 일과 지출의 흐름을 차분히 살펴봐요.',
+    slug: '직업',
+    mark: '△',
+  },
+  {
+    label: '마음과 생활',
+    title: '컨디션과 일상 리듬',
+    description: '몸과 마음의 속도를 조절할 작은 단서를 찾아요.',
+    slug: '건강',
+    mark: '○',
+  },
+] as const;
 
-export default function LandingPage() {
-  const dailyCost = getFortuneCostPoints('daily');
+const TRUST_POINTS = [
+  ['로그인 없이 시작 가능', '계정은 결과를 저장하고 싶을 때 만들어도 돼요.'],
+  ['약 1분 내 확인', '생년월일 하나로 오늘의 흐름을 읽어요.'],
+  ['모르는 정보는 건너뛰어요.', '선택 입력을 비워도 결과를 볼 수 있어요.'],
+  ['재미로 보는 리딩이에요.', '의료·법률·투자 등 전문적 조언을 대체하지 않아요.'],
+] as const;
 
+function requireFortune(type: string): WebFortune {
+  const fortune = WEB_FORTUNES.find((item) => item.fortuneType === type);
+  if (!fortune) throw new Error(`Missing web fortune: ${type}`);
+  return fortune;
+}
+
+const featuredFortunes = FEATURED.map((item) => ({ ...item, fortune: requireFortune(item.type) }));
+const todayFortune = requireFortune('daily');
+
+export default function HomePage() {
   return (
-    <main className="ondo-shell ondo-stack" style={{ gap: 'var(--ondo-spacing-xxl)' }}>
-      <header className="ondo-stack">
-        <p className="ondo-kicker">온도 · ONDO</p>
-        <h1 className="ondo-h1">
-          오늘 하루가 어떻게 흘러갈지,
-          <br />
-          생년월일 하나로 읽어드려요.
-        </h1>
-        <p className="ondo-muted">
-          앱을 설치하지 않아도 웹에서 바로 오늘의 운세를 볼 수 있습니다. 구글 계정으로 로그인해 이용할 수도 있습니다.
-        </p>
-        <div className="ondo-row" style={{ marginTop: 'var(--ondo-spacing-sm)' }}>
-          <Link className="ondo-button" href={fortuneHref('오늘')}>
-            오늘의 운세 보기
-          </Link>
-          <Link className="ondo-button ondo-button--secondary" href={FORTUNE_INDEX_HREF}>
-            운세 전체 보기
-          </Link>
-        </div>
-        <p className="ondo-muted">일일 운세 1회에 온도 {dailyCost}개가 사용됩니다.</p>
-      </header>
+    <main className={styles.home}>
+      <section className={styles.hero} aria-labelledby="home-title">
+        <div className={styles.heroInner}>
+          <div className={styles.heroCopy}>
+            <p className={styles.eyebrow}>온도 · ONDO</p>
+            <h1 id="home-title">오늘 하루가 어떻게 흘러갈지, 생년월일 하나로 읽어드려요.</h1>
+            <p className={styles.heroDescription}>
+              설치도 로그인도 필요 없어요. 생년월일을 알려주시면 오늘의 흐름을 편지처럼 정리해 드립니다.
+            </p>
+            <div className={styles.heroActions}>
+              <Link className={styles.primaryButton} href={fortuneHref(todayFortune.slug)}>
+                오늘의 운세 보기 <span aria-hidden="true">→</span>
+              </Link>
+              <Link className={styles.textLink} href="#result-preview">
+                어떤 결과가 나오나요? <span aria-hidden="true">↓</span>
+              </Link>
+            </div>
+            <p className={styles.heroNote}>
+              로그인 없이 바로 시작 · 1회에 온도 {todayFortune.costPoints}개가 사용돼요
+            </p>
+          </div>
 
-      <section className="ondo-stack" aria-labelledby="other-fortunes-heading">
-        <h2 className="ondo-h2" id="other-fortunes-heading">
-          오늘 말고도 볼 수 있는 것
-        </h2>
-        <div className="ondo-grid-2">
-          {OTHER_FORTUNES.map((fortune) => (
-            <FortuneLinkCard fortune={fortune} key={fortune.slug} />
+          <div className={styles.heroVisual} aria-label="오늘의 운세 결과 예시">
+            <span className={styles.sunHalo} aria-hidden="true">☼</span>
+            <article className={styles.previewLetter}>
+              <p className={styles.letterKicker}>오늘의 운세 · 예시</p>
+              <p className={styles.letterQuote}>서두르지 않아도 흐름이 당신 편인 날이에요.</p>
+              <div className={styles.letterDetails}>
+                <span><strong>오전</strong> 미뤄둔 연락 하나 보내기</span>
+                <span><strong>저녁</strong> 즉흥 지출은 잠시 두기</span>
+              </div>
+              <div className={styles.letterConversation}>
+                <span className={styles.miniAvatar} aria-hidden="true">하</span>
+                <span>결과를 두고 하은과 이어서 이야기할 수 있어요.</span>
+              </div>
+            </article>
+          </div>
+        </div>
+
+        <div className={styles.trustStrip} aria-label="온도 이용 원칙">
+          {TRUST_POINTS.map(([title, description], index) => (
+            <div className={styles.trustItem} key={title}>
+              <span className={styles.trustNumber} aria-hidden="true">0{index + 1}</span>
+              <p><strong>{title}</strong><span>{description}</span></p>
+            </div>
           ))}
         </div>
       </section>
 
-      <section className="ondo-stack" aria-labelledby="chat-heading">
-        <h2 className="ondo-h2" id="chat-heading">
-          운세만 보고 끝내지 않아도 돼요
-        </h2>
-        <Link className="ondo-card ondo-stack" href={CHAT_INDEX_HREF} style={{ gap: 'var(--ondo-spacing-xxs)' }}>
-          <h3 className="ondo-h3">캐릭터와 대화하기</h3>
-          <p className="ondo-muted">
-            결과를 두고 이야기를 이어갈 수 있어요. 대화가 쌓일수록 캐릭터가 나를 기억합니다.
-          </p>
-        </Link>
+      <section className={styles.section} aria-labelledby="purpose-title">
+        <div className={styles.sectionHeading}>
+          <p className={styles.eyebrow}>오늘의 질문</p>
+          <h2 id="purpose-title">지금 어떤 흐름이 궁금한가요?</h2>
+          <p>답을 정해주기보다, 지금의 마음을 읽고 다음 한 걸음을 고를 수 있게 도와드려요.</p>
+        </div>
+        <div className={styles.purposeGrid}>
+          {PURPOSES.map((purpose) => (
+            <Link className={styles.purposeCard} href={fortuneHref(purpose.slug)} key={purpose.label}>
+              <span className={styles.purposeMark} aria-hidden="true">{purpose.mark}</span>
+              <span className={styles.cardKicker}>{purpose.label}</span>
+              <h3>{purpose.title}</h3>
+              <p>{purpose.description}</p>
+              <span className={styles.cardArrow} aria-hidden="true">→</span>
+            </Link>
+          ))}
+        </div>
       </section>
 
-      <section className="ondo-stack" aria-labelledby="highlights-heading">
-        <h2 className="ondo-h2" id="highlights-heading">
-          온도가 하는 일
-        </h2>
-        {highlights.map((item) => (
-          <article className="ondo-card ondo-stack" key={item.kicker} style={{ gap: 'var(--ondo-spacing-xs)' }}>
-            <p className="ondo-kicker">{item.kicker}</p>
-            <h3 className="ondo-h3">{item.title}</h3>
-            <p className="ondo-muted">{item.body}</p>
-          </article>
-        ))}
+      <section className={`${styles.section} ${styles.featuredSection}`} aria-labelledby="featured-title">
+        <div className={styles.sectionHeadingRow}>
+          <div className={styles.sectionHeading}>
+            <p className={styles.eyebrow}>많이 찾는 리딩</p>
+            <h2 id="featured-title">가장 많이 찾는 운세</h2>
+          </div>
+          <Link className={styles.textLink} href={FORTUNE_INDEX_HREF}>전체 보기 <span aria-hidden="true">→</span></Link>
+        </div>
+        <div className={styles.fortuneGrid}>
+          {featuredFortunes.map(({ fortune, label, mark, tone }) => (
+            <Link className={styles.fortuneCard} data-tone={tone} href={fortuneHref(fortune.slug)} key={fortune.slug}>
+              <div className={styles.fortuneCardTop}>
+                <span className={styles.fortuneMark} aria-hidden="true">{mark}</span>
+                <span className={styles.cost}>온도 {fortune.costPoints}개</span>
+              </div>
+              <h3>{label}</h3>
+              <p>{fortune.blurb}</p>
+              <span className={styles.readLink}>리딩 시작 <span aria-hidden="true">→</span></span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.resultSection}`} id="result-preview" aria-labelledby="result-title">
+        <div className={styles.sectionHeading}>
+          <p className={styles.eyebrow}>결과 예시</p>
+          <h2 id="result-title">오늘의 리딩은 이렇게 도착해요</h2>
+          <p>긴 설명보다 오늘 기억할 한 문장, 조심할 순간, 바로 해볼 작은 행동을 순서대로 보여줘요.</p>
+        </div>
+        <div className={styles.resultCard}>
+          <div className={styles.resultStars} aria-hidden="true">✦　·　✧</div>
+          <div className={styles.resultMain}>
+            <p className={styles.resultDate}>오늘 · 오늘의 흐름</p>
+            <h3>밀어붙이기보다 정리할 때 길이 보여요.</h3>
+            <p className={styles.resultBody}>
+              오전에는 답이 늦어도 재촉하지 마세요. 오후가 되면 흐릿했던 우선순위가 자연스럽게 정리됩니다.
+              오늘은 새로운 일을 더하기보다, 이미 시작한 한 가지를 끝내는 쪽이 잘 맞아요.
+            </p>
+            <div className={styles.resultSignals}>
+              <span><small>기억할 행동</small> 미뤄둔 연락 하나 보내기</span>
+              <span><small>잠시 멈출 것</small> 기분에 따른 즉흥 지출</span>
+              <span><small>행운의 단서</small> 따뜻한 차와 저녁 산책</span>
+            </div>
+          </div>
+          <aside className={styles.resultAside}>
+            <span className={styles.resultAvatar} aria-hidden="true">하</span>
+            <p>“결과에서 마음에 걸린 문장, 그거부터 얘기해 봐.”</p>
+            <Link href={chatHref(WEB_CHAT_CHARACTERS[0].id)}>하은과 이야기하기 <span aria-hidden="true">→</span></Link>
+          </aside>
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.characterSection}`} aria-labelledby="character-title">
+        <div className={styles.sectionHeadingRow}>
+          <div className={styles.sectionHeading}>
+            <p className={styles.eyebrow}>AI 캐릭터</p>
+            <h2 id="character-title">결과를 보고 끝내지 말고, 오늘의 마음을 이어서 이야기해 보세요.</h2>
+            <p>정답을 대신 정하지 않는 네 명의 캐릭터가 각자의 말투로 먼저 말을 걸어요.</p>
+          </div>
+          <Link className={styles.textLink} href={CHAT_INDEX_HREF}>모두 만나기 <span aria-hidden="true">→</span></Link>
+        </div>
+        <div className={styles.characterGrid}>
+          {WEB_CHAT_CHARACTERS.map((character, index) => (
+            <Link className={styles.characterCard} href={chatHref(character.id)} key={character.id}>
+              <span className={styles.characterPortrait} data-index={index} aria-hidden="true">
+                {character.name.slice(0, 1)}
+              </span>
+              <span className={styles.cardKicker}>{character.relationship}</span>
+              <h3>{character.name}</h3>
+              <p>{character.tagline}</p>
+              <span className={styles.characterTags}>{character.tags.slice(0, 2).map((tag) => `#${tag}`).join(' ')}</span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.guideSection}`} id="ondo-guide" aria-labelledby="guide-title">
+        <div className={styles.sectionHeading}>
+          <p className={styles.eyebrow}>이용 안내</p>
+          <h2 id="guide-title">온도는 이렇게 사용해요</h2>
+          <p>운세를 보기 전에 필요한 온도를 확인할 수 있어요. 숨겨진 단계 없이 세 번이면 끝납니다.</p>
+        </div>
+        <ol className={styles.guideSteps}>
+          <li><span>1</span><strong>궁금한 운세를 고르기</strong><p>오늘, 사랑, 일과 돈, 생활 중 지금 필요한 흐름을 선택해요.</p></li>
+          <li><span>2</span><strong>사용할 온도 확인하기</strong><p>각 카드에 표시된 온도를 보고 시작 여부를 직접 결정해요.</p></li>
+          <li><span>3</span><strong>결과를 읽고 이어가기</strong><p>오늘 해볼 행동을 고르거나 캐릭터와 대화를 이어가요.</p></li>
+        </ol>
+        <p className={styles.guideNote}>운세 결과는 엔터테인먼트 목적이며 중요한 결정의 근거가 되어서는 안 됩니다.</p>
+      </section>
+
+      <section className={styles.finalCta} aria-labelledby="final-title">
+        <p className={styles.eyebrow}>오늘의 온도</p>
+        <h2 id="final-title">오늘을 바꿀 거창한 답보다, 지금 해볼 한 가지를 만나보세요.</h2>
+        <Link className={styles.primaryButton} href={fortuneHref(todayFortune.slug)}>
+          오늘의 운세 시작하기 <span aria-hidden="true">→</span>
+        </Link>
       </section>
     </main>
   );

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -1,14 +1,3 @@
-/**
- * 모든 페이지 하단 고지와 운영 문서 링크.
- *
- * 엔터테인먼트 문구는 새로 쓰지 않고 결과 화면이 쓰는 `Disclaimer` 를 그대로
- * 가져온다 — 같은 고지가 페이지마다 다른 문장이 되면 안 된다.
- *
- * 정책 문서는 기존 공개 검증 사이트의 배포본을 단일 원본으로 쓴다. Next 웹에서
- * 약관 문구를 복제하면 두 배포의 개정일과 내용이 갈릴 수 있으므로 외부 링크로
- * 명시적으로 연결한다.
- */
-
 import { Disclaimer } from '@/features/fortune/result';
 
 const PUBLIC_DOCUMENTS = [
@@ -20,33 +9,19 @@ const PUBLIC_DOCUMENTS = [
 
 export function SiteFooter() {
   return (
-    <footer style={{ borderTop: '1px solid var(--ondo-color-border)' }}>
-      <div
-        className="ondo-shell ondo-stack"
-        style={{
-          gap: 'var(--ondo-spacing-xs)',
-          paddingTop: 'var(--ondo-spacing-xl)',
-          paddingBottom: 'var(--ondo-spacing-xl)',
-        }}
-      >
-        <p className="ondo-kicker">온도 · ONDO</p>
-        <Disclaimer />
-        <nav
-          aria-label="운영 정보"
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 'var(--ondo-spacing-md)',
-            marginTop: 'var(--ondo-spacing-xs)',
-          }}
-        >
+    <footer className="ondo-site-footer">
+      <div className="ondo-footer-inner">
+        <div className="ondo-footer-brand">
+          <strong>온도 · ONDO</strong>
+          <Disclaimer />
+        </div>
+        <nav className="ondo-footer-links" aria-label="운영 정보">
           {PUBLIC_DOCUMENTS.map((document) => (
-            <a href={document.href} key={document.href}>
-              {document.label}
-            </a>
+            <a href={document.href} key={document.href}>{document.label}</a>
           ))}
         </nav>
       </div>
+      <p className="ondo-footer-bottom">© ONDO · 오늘의 마음을 읽는 작은 리딩</p>
     </footer>
   );
 }

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -1,56 +1,45 @@
-/**
- * 모든 페이지 상단 내비게이션.
- *
- * 세션을 읽지 않는다 — 루트 레이아웃에서 렌더되므로 여기서 `auth.getUser()` 를
- * 부르면 정적 페이지 전부가 dynamic 으로 떨어진다. 로그인 여부는 링크가 아니라
- * 도착한 페이지에서 판단한다.
- *
- * globals.css 는 이 작업 범위 밖이라 새 클래스를 만들지 않고 기존 .ondo-* 조합 +
- * 토큰 인라인 스타일로만 만든다. 색은 전부 var(--ondo-*).
- */
-
 import Link from 'next/link';
 
-import { IS_BYOK_ENABLED, SETTINGS_AI_HREF } from '@/features/settings/providers';
 import { CHAT_INDEX_HREF, FORTUNE_INDEX_HREF } from '@/lib/href';
 
-/**
- * 설정 링크는 `/설정` 이 아니라 `/설정/ai` 로 간다 — 지금 설정 화면은 AI 키
- * 연결 하나뿐이고, 목록만 있는 `/설정` 을 만들면 클릭이 한 번 더 늘 뿐이다.
- * 그래서 개인 키 연결이 꺼져 있으면 설정 항목 자체를 내보내지 않는다
- * (`IS_BYOK_ENABLED` 주석 참고).
- */
 const NAV_LINKS = [
   { href: FORTUNE_INDEX_HREF, label: '운세' },
-  { href: CHAT_INDEX_HREF, label: '대화' },
-  ...(IS_BYOK_ENABLED ? [{ href: SETTINGS_AI_HREF, label: '설정' }] : []),
-  { href: '/auth/login', label: '로그인' },
-];
+  { href: CHAT_INDEX_HREF, label: '캐릭터 대화' },
+  { href: '/#ondo-guide', label: '온도 이용 안내' },
+] as const;
+
+function NavigationLinks() {
+  return (
+    <>
+      {NAV_LINKS.map((link) => (
+        <Link href={link.href} key={link.href}>{link.label}</Link>
+      ))}
+      <Link href="/auth/login">로그인</Link>
+    </>
+  );
+}
 
 export function SiteHeader() {
   return (
-    <header style={{ borderBottom: '1px solid var(--ondo-color-border)' }}>
-      {/* .ondo-shell 로 본문과 같은 폭/좌우 여백을 쓰고 세로 여백만 덮어쓴다. */}
-      <nav
-        aria-label="사이트 메뉴"
-        className="ondo-shell ondo-row"
-        style={{
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          paddingTop: 'var(--ondo-spacing-md)',
-          paddingBottom: 'var(--ondo-spacing-md)',
-        }}
-      >
-        <Link href="/">온도</Link>
+    <header className="ondo-site-header">
+      <div className="ondo-site-nav">
+        <Link className="ondo-site-logo" href="/" aria-label="온도 홈">온도</Link>
 
-        <div className="ondo-row" style={{ gap: 'var(--ondo-spacing-md)' }}>
+        <nav className="ondo-desktop-nav" aria-label="사이트 메뉴">
           {NAV_LINKS.map((link) => (
-            <Link className="ondo-muted" href={link.href} key={link.href}>
-              {link.label}
-            </Link>
+            <Link href={link.href} key={link.href}>{link.label}</Link>
           ))}
+        </nav>
+
+        <div className="ondo-header-actions">
+          <Link className="ondo-login-link" href="/auth/login">로그인</Link>
         </div>
-      </nav>
+
+        <details className="ondo-mobile-menu">
+          <summary>메뉴</summary>
+          <nav aria-label="모바일 사이트 메뉴"><NavigationLinks /></nav>
+        </details>
+      </div>
     </header>
   );
 }

--- a/playwright.web.config.js
+++ b/playwright.web.config.js
@@ -25,6 +25,9 @@ module.exports = defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     actionTimeout: 15000,
+    launchOptions: process.env.PLAYWRIGHT_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH }
+      : undefined,
   },
   projects: [
     {

--- a/playwright/tests/web/home-redesign.spec.js
+++ b/playwright/tests/web/home-redesign.spec.js
@@ -1,0 +1,99 @@
+const { test, expect } = require('@playwright/test');
+
+const HOME_SECTIONS = [
+  '지금 어떤 흐름이 궁금한가요?',
+  '가장 많이 찾는 운세',
+  '오늘의 리딩은 이렇게 도착해요',
+  '결과를 보고 끝내지 말고, 오늘의 마음을 이어서 이야기해 보세요.',
+  '온도는 이렇게 사용해요',
+];
+
+test.describe('Warm Celestial Editorial home', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('builds one clear path from the value proposition to a real reading', async ({ page }) => {
+    await expect(page.getByRole('heading', {
+      level: 1,
+      name: '오늘 하루가 어떻게 흘러갈지, 생년월일 하나로 읽어드려요.',
+    })).toBeVisible();
+    await expect(page.getByRole('link', { name: '오늘의 운세 보기', exact: true }).first()).toHaveAttribute(
+      'href',
+      /%EC%98%A4%EB%8A%98|오늘/,
+    );
+    await expect(page.getByRole('link', { name: '어떤 결과가 나오나요?' })).toHaveAttribute(
+      'href',
+      '#result-preview',
+    );
+    await expect(page.getByText('로그인 없이 시작 가능', { exact: true })).toBeVisible();
+    await expect(page.getByText('약 1분 내 확인', { exact: true })).toBeVisible();
+  });
+
+  test('exposes the full editorial story without inventing unavailable services', async ({ page }) => {
+    for (const heading of HOME_SECTIONS) {
+      await expect(page.getByRole('heading', { name: heading })).toBeVisible();
+    }
+
+    for (const fortune of ['오늘의 운세', '오늘의 타로', '연애운', '재물운']) {
+      await expect(page.getByRole('heading', { name: fortune, exact: true })).toBeVisible();
+    }
+
+    for (const character of ['서하은', '차도경', '윤제이', '한소월']) {
+      await expect(page.getByRole('heading', { name: character, exact: true })).toBeVisible();
+    }
+
+    await expect(page.getByText('AI 캐릭터', { exact: true })).toBeVisible();
+    await expect(page.getByText('온도 1개', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('온도 5개', { exact: true }).first()).toBeVisible();
+  });
+
+  test('uses the shared warm editorial visual system', async ({ page }) => {
+    const body = page.locator('body');
+    await expect(body).toHaveCSS('background-color', 'rgb(247, 242, 234)');
+    await expect(body).toHaveCSS('color', 'rgb(25, 23, 22)');
+
+    const heading = page.getByRole('heading', { level: 1 });
+    const headingFont = await heading.evaluate((element) => getComputedStyle(element).fontFamily);
+    expect(headingFont).toMatch(/MaruBuri|Noto Serif KR|serif/i);
+
+    const mainWidth = await page.locator('main').evaluate((element) => element.getBoundingClientRect().width);
+    expect(mainWidth).toBeGreaterThanOrEqual(1100);
+  });
+
+  test('keeps editorial body copy readable and the example evergreen', async ({ page }) => {
+    const bodyCopy = [
+      page.getByText('로그인 없이 바로 시작 · 1회에 온도 1개가 사용돼요'),
+      page.getByText('지금 밀어도 되는 일과 잠시 두어야 할 일을 봐요.'),
+      page.getByText('운세 결과는 엔터테인먼트 목적이며 중요한 결정의 근거가 되어서는 안 됩니다.'),
+    ];
+
+    for (const copy of bodyCopy) {
+      await expect(copy).toHaveCSS('font-size', '16px');
+    }
+
+    await expect(page.getByText('오늘 · 오늘의 흐름', { exact: true })).toBeVisible();
+    await expect(page.getByText('8월 24일 · 오늘의 흐름', { exact: true })).toHaveCount(0);
+
+    const resultBody = page.getByText(/오전에는 답이 늦어도 재촉하지 마세요/);
+    const lineHeightRatio = await resultBody.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return Number.parseFloat(style.lineHeight) / Number.parseFloat(style.fontSize);
+    });
+    expect(lineHeightRatio).toBeGreaterThanOrEqual(1.65);
+  });
+
+  test('keeps mobile discovery usable without horizontal overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload();
+
+    const sizes = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(sizes.scrollWidth).toBeLessThanOrEqual(sizes.clientWidth);
+
+    await expect(page.locator('summary', { hasText: '메뉴' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '오늘의 운세 보기', exact: true }).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild the ONDO web home with a warm celestial editorial visual system
- connect the landing story from fortune discovery to result preview, AI character conversation, and 온도 usage guidance
- add responsive navigation/footer treatment, readable body typography, reduced-motion support, and Playwright regression coverage
- allow the web Playwright config to use a system Chrome executable when provided

## Verification
- `pnpm run check:web-tokens`
- `pnpm run web:typecheck`
- `pnpm run web:build`
- `pnpm run web:validate` — 276 checks passed
- `PLAYWRIGHT_EXECUTABLE_PATH=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome pnpm run test:web` — 11 passed, 1 deployed-environment-only test skipped
- desktop 1440px and mobile 390px visual QA, no horizontal overflow

## Deployment note
- Existing Vercel production routes `/`, `/운세`, `/대화`, and `/운세/오늘` all return HTTP 200.
- Preview and merged production deployments must be verified before completion.