### PR TITLE
[NO-JIRA] Clarify Ondo web launch status

### DIFF
--- a/playwright/tests/ondo-public-site.spec.js
+++ b/playwright/tests/ondo-public-site.spec.js
@@ -134,6 +134,19 @@ test.describe('public routes', () => {
   });
 });
 
+test.describe('web launch status', () => {
+  test('home tells visitors what is available on the web today', async ({ page }) => {
+    await page.goto(url('/'));
+
+    await expect(page.locator('h1')).toContainText('웹서비스 출시 안내');
+    await expect(page.getByTestId('web-launch-status')).toContainText('준비 중');
+    await expect(page.getByTestId('web-available-now')).toContainText('공개 문서와 고객 지원');
+    await expect(page.getByTestId('web-not-available')).toContainText(
+      '운세 결과, 로그인, 결제 기능은 아직 웹에서 제공하지 않습니다',
+    );
+  });
+});
+
 test.describe('layout', () => {
   for (const [label, viewport] of [
     ['desktop 1440x1000', DESKTOP_VIEWPORT],

--- a/public/index.html
+++ b/public/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Ondo 공개 검증 페이지</title>
+    <title>온도 웹서비스 출시 안내 | Ondo</title>
     <meta
       name="description"
-      content="Ondo(온도) 앱 심사·지원용 공개 페이지입니다. 개인정보처리방침, 이용약관, 고객 지원, 계정 삭제 안내와 도메인 검증 파일을 제공합니다."
+      content="온도(Ondo)의 웹 운세 서비스 출시 준비 현황과 현재 이용 가능한 개인정보처리방침, 이용약관, 고객 지원, 계정 삭제 안내를 확인하세요."
     />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
@@ -16,18 +16,19 @@
     <a class="skip-link" href="#main" data-testid="skip-link">본문으로 건너뛰기</a>
     <main id="main" tabindex="-1">
       <div class="meta">
-        <span>Store Review</span>
-        <span>Support</span>
-        <span>Deep Link Verification</span>
+        <span data-testid="web-launch-status">웹 운세 출시 준비 중</span>
+        <span>공개 문서 제공 중</span>
+        <span>고객 지원 운영 중</span>
       </div>
-      <h1>Ondo 공개 검증 페이지</h1>
-      <p>
-        App Store / Google Play 심사에 필요한 공개 문서와 도메인 검증 파일을 한곳에서 확인할 수 있도록
-        정리한 페이지입니다.
+      <h1>온도 웹서비스 출시 안내</h1>
+      <p data-testid="web-available-now">
+        온도는 질문과 상황에 맞는 운세를 웹에서 편안하게 확인할 수 있는 서비스를 준비하고 있습니다.
+        웹 운세 기능은 아직 출시 전이며, 현재는 공개 문서와 고객 지원 안내를 이용할 수 있습니다.
       </p>
-      <p class="caption">
-        최종 업데이트: 2026년 8월 22일. 이 사이트는 Ondo 앱의 공개 문서와 지원 창구만 제공하는 정적
-        페이지이며, 로그인·결제·채팅 같은 제품 기능은 앱에서만 제공합니다.
+      <p class="caption" data-testid="web-not-available">
+        최종 업데이트: 2026년 8월 26일. 운세 결과, 로그인, 결제 기능은 아직 웹에서 제공하지 않습니다.
+        출시 전까지 개인정보처리방침, 이용약관, 고객 지원, 계정 삭제 안내와 도메인 검증 파일을 이
+        페이지에서 확인할 수 있습니다.
       </p>
       <ul class="link-list">
         <li><a href="/privacy">개인정보처리방침 보기</a></li>


### PR DESCRIPTION
## Summary
- replace the app-review-first homepage framing with a truthful web-service launch notice
- distinguish what visitors can use now from web features that are still unavailable
- preserve all existing legal, support, account-deletion, and deep-link routes
- add a rendered-behavior regression for the launch-status disclosure

## Risk
- Tier 1, static homepage presentation only
- no mobile, backend, auth, payment, legal-text, database, or domain/DNS changes

## Verification
- `node scripts/validate-ondo-web-readiness.mjs` — PASS 276 checks
- public-site Playwright suite with installed Chrome — 44 passed
- desktop 1440×1000 and mobile 390×844 runtime capture — HTTP 200, no horizontal overflow, no console errors, no failed requests