### PR TITLE
fix(web): avoid Unicode RSC header failures

### DIFF
--- a/apps/web/src/app/app/charge/fail/page.tsx
+++ b/apps/web/src/app/app/charge/fail/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 export const metadata: Metadata = {
   title: '결제 미완료',

--- a/apps/web/src/app/app/charge/page.tsx
+++ b/apps/web/src/app/app/charge/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { redirect } from 'next/navigation';
 
 import { tossClientKey } from '@/lib/env';

--- a/apps/web/src/app/app/charge/success/payment-success-client.tsx
+++ b/apps/web/src/app/app/charge/success/payment-success-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 

--- a/apps/web/src/app/app/page.tsx
+++ b/apps/web/src/app/app/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { redirect } from 'next/navigation';
 
 import { getFortuneCostPoints } from '@fortune/product-contracts';

--- a/apps/web/src/app/app/payments/page.tsx
+++ b/apps/web/src/app/app/payments/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { redirect } from 'next/navigation';
 
 import { createSupabaseServerClient } from '@/lib/supabase/server';

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { useEffect } from 'react';
 
 export default function ErrorPage({

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 export default function NotFound() {
   return (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 export const metadata: Metadata = {
   alternates: { canonical: '/' },

--- a/apps/web/src/app/운세/띠별/[animal]/page.tsx
+++ b/apps/web/src/app/운세/띠별/[animal]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { fortuneHref } from '@/lib/href';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { notFound } from 'next/navigation';
 
 import { ZodiacForm } from '@/features/f-b/zodiac-form';

--- a/apps/web/src/app/운세/띠별/page.tsx
+++ b/apps/web/src/app/운세/띠별/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { encodePath } from '@/lib/href';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 import { ZodiacForm } from '@/features/f-b/zodiac-form';
 import { ZODIAC_ANIMALS } from '@/features/f-b/zodiac-animals';

--- a/apps/web/src/app/운세/엠비티아이/[type]/page.tsx
+++ b/apps/web/src/app/운세/엠비티아이/[type]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { fortuneHref } from '@/lib/href';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { notFound } from 'next/navigation';
 
 import { MbtiForm } from '@/features/f-b/mbti-form';

--- a/apps/web/src/app/운세/엠비티아이/page.tsx
+++ b/apps/web/src/app/운세/엠비티아이/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { encodePath } from '@/lib/href';
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 import { MbtiForm } from '@/features/f-b/mbti-form';
 import { MBTI_TYPES } from '@/features/f-b/mbti-types';

--- a/apps/web/src/components/account-header-actions.tsx
+++ b/apps/web/src/components/account-header-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { useEffect, useState } from 'react';
 
 import { getBrowserSupabase } from '@/lib/supabase/client';

--- a/apps/web/src/components/app-link.tsx
+++ b/apps/web/src/components/app-link.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import NextLink from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { AnchorHTMLAttributes } from 'react';
+
+import { requiresNativeNavigation } from '@/lib/href';
+
+type AppLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+  href: string;
+  prefetch?: boolean | null;
+};
+
+/**
+ * Preserve Next client navigation for ASCII routes, but use a native document
+ * navigation whenever Korean route state would be copied into an RSC header.
+ */
+export function AppLink({ href, prefetch, ...props }: AppLinkProps) {
+  const currentPath = usePathname();
+
+  if (requiresNativeNavigation(currentPath, href)) {
+    return <a href={href} {...props} />;
+  }
+
+  return <NextLink href={href} prefetch={prefetch} {...props} />;
+}

--- a/apps/web/src/components/fortune-link-card.tsx
+++ b/apps/web/src/components/fortune-link-card.tsx
@@ -5,7 +5,7 @@
  * 여기서 문구를 새로 쓰거나 숫자를 하드코딩하지 않는다.
  */
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 import { fortuneHref } from '@/lib/href';
 

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 import { AccountHeaderActions } from '@/components/account-header-actions';
 import { CHAT_INDEX_HREF, FORTUNE_INDEX_HREF } from '@/lib/href';

--- a/apps/web/src/features/chat/character-picker.tsx
+++ b/apps/web/src/features/chat/character-picker.tsx
@@ -3,7 +3,7 @@
  * 소개가 HTML 로 들어가야 검색/링크 프리뷰에 잡힌다.
  */
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 import { chatHref } from '@/lib/href';
 

--- a/apps/web/src/features/chat/chat-thread.tsx
+++ b/apps/web/src/features/chat/chat-thread.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import {
   useCallback,
   useEffect,

--- a/apps/web/src/features/daily/daily-result.tsx
+++ b/apps/web/src/features/daily/daily-result.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 
 import {
   CardList,

--- a/apps/web/src/features/fortune/fortune-chat-bridge.tsx
+++ b/apps/web/src/features/fortune/fortune-chat-bridge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { useEffect, useState } from 'react';
 
 interface ContextPointer {

--- a/apps/web/src/features/fortune/result.tsx
+++ b/apps/web/src/features/fortune/result.tsx
@@ -11,7 +11,7 @@
  * 서버 컴포넌트로 그대로 쓸 수 있게 순수하게 유지한다 ('use client' 없음).
  */
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import type { ReactNode } from 'react';
 
 import type { FortuneFailureKind } from './runner';

--- a/apps/web/src/features/settings/ai-key-settings.tsx
+++ b/apps/web/src/features/settings/ai-key-settings.tsx
@@ -17,7 +17,7 @@
  * 색은 전부 var(--ondo-*), 클래스는 globals.css 의 .ondo-* 만 쓴다.
  */
 
-import Link from 'next/link';
+import { AppLink as Link } from '@/components/app-link';
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 
 import { ChipSelect, TextField } from '@/features/fortune/fields';

--- a/apps/web/src/lib/href.test.ts
+++ b/apps/web/src/lib/href.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { requiresNativeNavigation } from './href.ts';
+
+test('uses native navigation when the current or destination pathname contains Korean segments', () => {
+  assert.equal(requiresNativeNavigation('/', '/%EC%9A%B4%EC%84%B8'), true);
+  assert.equal(requiresNativeNavigation('/운세', '/support'), true);
+  assert.equal(requiresNativeNavigation('/support', '/terms'), false);
+});

--- a/apps/web/src/lib/href.ts
+++ b/apps/web/src/lib/href.ts
@@ -14,14 +14,34 @@
  * 보이지만, soft navigation 이 전부 죽고 콘솔이 에러로 도배된다.
  * (실제로 배포 후 브라우저 콘솔에서 확인함 — 모든 링크에서 발생)
  *
- * 미리 퍼센트 인코딩해 두면 헤더 값이 ASCII 로 유지돼 정상 동작한다.
- * 주소창은 어차피 디코딩해서 보여주므로 사용자에게 보이는 URL 은 그대로 한글이다.
+ * 목적지 경로의 퍼센트 인코딩은 필수지만, 현재 경로를 담는 Next-Url 이 다시
+ * 디코딩될 수 있어 그것만으로는 충분하지 않다. `AppLink`가 한글 경로 전환을
+ * native navigation으로 격리하고, 이 헬퍼들은 목적지 자체를 ASCII로 유지한다.
+ * 주소창은 디코딩해서 보여주므로 사용자에게 보이는 URL은 그대로 한글이다.
  */
 export function encodePath(path: string): string {
   return path
     .split('/')
     .map((segment) => encodeURIComponent(segment))
     .join('/');
+}
+
+function hasUnicodePathSegment(path: string): boolean {
+  try {
+    return /[^\u0000-\u007f]/.test(decodeURI(path));
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Next App Router serialises route state into request headers. When either side
+ * of a client transition has a Korean segment, that state can contain raw
+ * Unicode and Chromium rejects the RSC request before it leaves the browser.
+ * Use a normal document navigation for those transitions instead.
+ */
+export function requiresNativeNavigation(currentPath: string, destination: string): boolean {
+  return hasUnicodePathSegment(currentPath) || hasUnicodePathSegment(destination);
 }
 
 /** `/운세/<slug>` */

--- a/playwright/tests/web/navigation.spec.ts
+++ b/playwright/tests/web/navigation.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test('Korean route links do not emit non-ISO RSC header errors', async ({ page }) => {
+  const rscHeaderErrors: string[] = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error' && message.text().includes('non ISO-8859-1 code point')) {
+      rscHeaderErrors.push(message.text());
+    }
+  });
+
+  await page.goto('/');
+  await page.getByRole('link', { name: '운세', exact: true }).first().hover();
+  await page.waitForTimeout(750);
+
+  expect(rscHeaderErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- route Korean-path transitions through a shared native-navigation fallback
- preserve Next.js client navigation for ASCII-only routes
- add unit and Playwright regression coverage for the non-ISO RSC header failure

## Test plan
- `node --experimental-strip-types --test apps/web/src/lib/account-data.test.ts apps/web/src/lib/analytics.test.ts apps/web/src/lib/fortune-context.test.ts apps/web/src/lib/google-auth.test.ts apps/web/src/lib/href.test.ts` (11 passed)
- `pnpm --filter @fortune/web typecheck`
- `pnpm exec playwright test --config=playwright.web.config.js --project=chromium --workers=1` (19 passed, 2 existing skips)
- production build completed by Playwright webServer
- added-line secret scan passed

## Existing unrelated validator note
- `pnpm run web:validate` remains red on the pre-existing root `index.html does not reference zpzg.co.kr` check; this change does not touch that artifact.